### PR TITLE
2-fix-implement-headers-validation

### DIFF
--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -1,4 +1,5 @@
 const Stream = require("node:stream");
+const http = require("node:http");
 const protocols = require("../protocols");
 const defaults = require("../defaults");
 const deepMerge = require("../utils/deepMerge");
@@ -35,6 +36,14 @@ class Nexis {
     }
 
     setConfig(newConfig = defaults.config()) {
+        // Validate headers config
+        if (newConfig.headers) {
+            Object.entries(newConfig.headers).forEach(([name, value]) => {
+                http.validateHeaderName(name);
+                http.validateHeaderValue(name, value);
+            });
+        }
+        
         this.#config = deepMerge(defaults.config(), newConfig);
     }
 }

--- a/tests/Nexis.test.js
+++ b/tests/Nexis.test.js
@@ -36,6 +36,39 @@ describe("Nexis instance", () => {
         assert.deepStrictEqual(client.getConfig(), { ...defaults.config(), ...otherConfig });
     });
 
+    it("should validate request header", () => {
+        const invalidTokenErr = (err) => err instanceof TypeError && err.code === "ERR_INVALID_HTTP_TOKEN";
+        const invalidValueErr = (err) => err instanceof TypeError && err.code === "ERR_HTTP_INVALID_HEADER_VALUE";
+        
+        // Validate name during set
+        assert.throws(
+            () => client.setConfig({ headers: { "content type": "application/json" } }),
+            invalidTokenErr,
+            "should reject invalid header name on set"
+        );
+
+        // Validate value during set
+        assert.throws(
+            () => client.setConfig({ headers: { "content-type": undefined }}),
+            invalidValueErr,
+            "should reject invalid header value on set"
+        );
+
+        // Validate name during request
+        assert.rejects(
+            async () => await client.get("/", { headers: { "content type": "application/json" }}),
+            invalidTokenErr,
+            "should reject invalid header name on request"
+        );
+
+        // Validate value during request
+        assert.rejects(
+            async () => await client.get("/", { headers: { "content-type": undefined }}),
+            invalidValueErr,
+            "should reject invalid header value on request"
+        );
+    });
+
     it("should have request methods", () => {
         assert.strictEqual(typeof client.get, "function");
         assert.strictEqual(typeof client.delete, "function");


### PR DESCRIPTION
This pull request is to merge the branch `2-fix-implement-headers-validation` into the `main` branch.

Implemented validation of the `headers` of a `ClientRequest` using the `validateHeaderName` & `validateHeaderValue` methods of `http`.