### PR TITLE
16-fix-incorrect-inheritance-of-http-https-properties

### DIFF
--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -15,6 +15,12 @@ class Nexis {
         
         this.setBaseURL(baseURL);
         this.setConfig(otherConfig);
+
+        // Inherit exclusive http properties
+        ["ClientRequest", "IncomingMessage", "OutgoingMessage", "METHODS", "STATUS_CODES", 
+            "maxHeaderSize", "validateHeaderName", "validateHeaderValue"].forEach((property) =>
+            Nexis.prototype[property] = http[property]
+        );
     }
 
     getBaseURL() {
@@ -29,8 +35,7 @@ class Nexis {
         this.#baseURL = new URL(newBaseURL, defaults.baseURL);
 
         // Inherit methods from new protocol
-        ["Agent", "ClientRequest", "IncomingMessage", "OutgoingMessage", "METHODS", "STATUS_CODES", "globalAgent", "maxHeaderSize", "request", 
-            "validateHeaderName", "validateHeaderValue"].forEach((property) => 
+        ["Agent", "globalAgent", "request"].forEach((property) => 
             Nexis.prototype[property] = protocols[this.#baseURL.protocol][property]
         );
     }

--- a/tests/Nexis.test.js
+++ b/tests/Nexis.test.js
@@ -1,5 +1,6 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
+const http = require("node:http");
 const Nexis = require("../lib/core/Nexis");
 const defaults = require("../lib/defaults");
 const protocols = require("../lib/protocols");
@@ -80,15 +81,17 @@ describe("Nexis instance", () => {
     it("should have inherited instance attributes", () => {
         const protocol = protocols[client.getBaseURL().protocol];
         assert.deepStrictEqual(client.Agent, protocol.Agent);
-        assert.deepStrictEqual(client.ClientRequest, protocol.ClientRequest);
-        assert.deepStrictEqual(client.IncomingMessage, protocol.IncomingMessage);
-        assert.deepStrictEqual(client.OutgoingMessage, protocol.OutgoingMessage);
-        assert.deepStrictEqual(client.METHODS, protocol.METHODS);
-        assert.deepStrictEqual(client.STATUS_CODES, protocol.STATUS_CODES);
         assert.deepStrictEqual(client.globalAgent, protocol.globalAgent);
-        assert.deepStrictEqual(client.maxHeaderSize, protocol.maxHeaderSize);
         assert.deepStrictEqual(client.request, protocol.request);
-        assert.deepStrictEqual(client.validateHeaderName, protocol.validateHeaderName);
-        assert.deepStrictEqual(client.validateHeaderValue, protocol.validateHeaderValue);
+
+        // Exclusive http properties
+        assert.deepStrictEqual(client.ClientRequest, http.ClientRequest);
+        assert.deepStrictEqual(client.IncomingMessage, http.IncomingMessage);
+        assert.deepStrictEqual(client.OutgoingMessage, http.OutgoingMessage);
+        assert.deepStrictEqual(client.METHODS, http.METHODS);
+        assert.deepStrictEqual(client.STATUS_CODES, http.STATUS_CODES);
+        assert.deepStrictEqual(client.maxHeaderSize, http.maxHeaderSize);
+        assert.deepStrictEqual(client.validateHeaderName, http.validateHeaderName);
+        assert.deepStrictEqual(client.validateHeaderValue, http.validateHeaderValue);
     });
 });


### PR DESCRIPTION
This pull request is to merge the branch `16-fix-incorrect-inheritance-of-http-https-properties` into the `main` branch.

Fixed the inheritance of properties from the `http` & `https` modules. The issue is that `https` doesn’t have all the same properties as `http`.