### PR TITLE
3-fix-break-body-into-chunks

### DIFF
--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -1,4 +1,4 @@
-const Stream = require("node:stream");
+const { Readable } = require("node:stream");
 const http = require("node:http");
 const protocols = require("../protocols");
 const defaults = require("../defaults");
@@ -100,6 +100,7 @@ class Nexis {
         });
 
         req.on("error", (err) => {
+            req.destroy(err);
             cb && cb(defaults.res(), err);
             reject(err);
         });
@@ -160,28 +161,20 @@ class Nexis {
         });
 
         req.on("error", (err) => {
+            req.destroy(err);
             cb && cb(defaults.res(), err);
             reject(err);
         });
-        
-        if (data instanceof Stream) {
-            data.pipe(req);
-            data.on("error", (err) => {
-                cb && cb(defaults.res(), err);
-                reject(err);
-            });
-            return;
-        }
 
-        // Sends body data
-        req.write(data, (err) => {
-            if (err) {
-                cb && cb(defaults.res(), err);
-                reject(err);
-            }
+        // Coverts data into Readable Stream
+        //      Feeds data into writable stream "req"
+        const readData = Readable.from(data);
+        readData.pipe(req);
+        readData.on("error", (err) => {
+            req.destroy(err);
+            cb && cb(defaults.res(), err);
+            reject(err);
         });
-
-        req.end();
     });
 });
 


### PR DESCRIPTION
This pull request is to merge the branch `3-fix-break-body-into-chunks` into the `main` branch.

Implement conversion of `body` data into `Readable` `Stream` and utilised the inbuilt `pipe` method to feed the `data` into the `req` `writable` `Stream` object. Automatically handles breaking the `data` into chunks. Additionally, implemented better error handling to `destroy` the `req` object to avoid memory leakage.