### PR TITLE
14-refactor-remove-repetitive-code-from-readwrite-methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -120,6 +120,16 @@ export class Nexis {
     setConfig(newConfig?: http.RequestOptions): void;
 
     /**
+     * Makes a read request which is either a `get` or `delete` method.
+     */
+    read(path: string | URL, method: "get" | "delete", configOrCb?: http.RequestOptions | NexisCallback, cb?: NexisCallback): Promise<http.IncomingMessage>;
+
+    /**
+     * Makes a write request which is either a `post`, `put` or `patch` method.
+     */
+    write(path: string | URL, method: "post" | "put" | "patch", configOrCb?: http.RequestOptions | NexisCallback, cb?: NexisCallback): Promise<http.IncomingMessage>;
+
+    /**
      * Make a http(s) get request.
      */
     get(path: string | URL, configOrCb?: http.RequestOptions | NexisCallback, cb?: NexisCallback): Promise<http.IncomingMessage>;

--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -51,131 +51,111 @@ class Nexis {
         
         this.#config = deepMerge(defaults.config(), newConfig);
     }
+
+    #handleCallbackConfig(configOrCb, cb) {
+        // Resolve callback
+        if (typeof configOrCb === "function") {
+            cb = configOrCb;
+        }
+
+        // Merge configs
+        configOrCb = deepMerge(deepMerge(defaults.config(), this.#config), configOrCb ?? {});
+
+        return [configOrCb, cb];
+    }
+
+    #generateHandlers(resolve, reject, cb) {
+        const handleResolve = (res) => {
+            cb && cb(res);
+            resolve(res);
+        }
+
+        const handleReject = (res, err) => {
+            cb && cb(res, err);
+            reject(err);
+        }
+
+        return [handleResolve, handleReject];
+    }
+
+    #request(path, method, config, onResolve, onReject) {
+        const url = new URL(path, this.#baseURL);
+        const req = protocols[url.protocol].request({
+            protocol: url.protocol,
+            hostname: url.hostname,
+            port: url.port,
+            path: url.pathname + url.search,
+            method,
+            ...config
+        }, (res) => {
+            res.data = "";
+
+            const chunks = [];
+            res.on("data", (chunk) => {
+                chunks.push(chunk);
+            });
+
+            res.on("end", () => {
+                // Combines chunks
+                res.data = Buffer.concat(chunks).toString();
+
+                // Converts response data based off headers
+                //      Parse json object or construct URLSearchParams
+                res.data = decodeData(res.data, res.headers["content-type"]);
+                
+                onResolve(res);
+            });
+        });
+
+        req.on("error", (err) => {
+            req.destroy(err);
+            onReject(defaults.res(), err);
+        });
+
+        return req;
+    }
+
+    read(path, method, configOrCb, cb) {
+        return new Promise((resolve, reject) => {
+            // Resolve callback & merge configs
+            const [config, callback] = this.#handleCallbackConfig(configOrCb, cb);
+
+            const req = this.#request(path, method, config, ...this.#generateHandlers(resolve, reject, callback));
+
+            req.end();
+        });
+    }
+
+    write(path, method, body, configOrCb, cb) {
+        return new Promise((resolve, reject) => {
+            // Resolve callback & merge configs
+            let [config, callback] = this.#handleCallbackConfig(configOrCb, cb);
+
+            // Encodes data & merges auto configuration
+            const [data, headers] = encodeConfigBody(body);
+            config = deepMerge({ headers }, config);
+
+            const req = this.#request(path, method, config, ...this.#generateHandlers(resolve, reject, callback));
+
+            const readData = Readable.from(data);
+            readData.pipe(req);
+            readData.on("error", (err) => {
+                req.destroy(err);
+                callback && callback(defaults.res(), err);
+                reject(err);
+            });
+        });
+    }
 }
 
 // Creates read requests
-["get", "delete"].forEach((method) => Nexis.prototype[method] = function (path, configOrCb, cb) {
-    return new Promise((resolve, reject) => {
-        // Resolve callback and config params
-        let config = deepMerge(defaults.config(), this.getConfig());
-        if (typeof configOrCb === "function") {
-            cb = configOrCb;
-        } else if (configOrCb) {
-            config = deepMerge(config, configOrCb);
-        }
-        
-        const url = new URL(path, this.getBaseURL());
-        const req = protocols[url.protocol].request({
-            protocol: url.protocol,
-            hostname: url.hostname,
-            port: url.port,
-            path: url.pathname + url.search,
-            method,
-            ...config
-        }, (res) => {
-            res.data = "";
-
-            const chunks = [];
-            res.on("data", (chunk) => {
-                if (typeof chunk === "string") {
-                    res.data += chunk;
-                    return;
-                }
-
-                chunks.push(chunk);
-            });
-
-            res.on("end", () => {
-                // Combines chunks
-                if (chunks.length > 0)
-                    res.data = Buffer.concat(chunks).toString();
-
-                // Converts response data based off headers
-                //      Parse json object or construct URLSearchParams
-                res.data = decodeData(res.data, res.headers["content-type"]);
-                
-                cb && cb(res);
-                resolve(res);
-            });
-        });
-
-        req.on("error", (err) => {
-            req.destroy(err);
-            cb && cb(defaults.res(), err);
-            reject(err);
-        });
-
-        req.end();
-    });
+["get", "delete"].forEach((method) => Nexis.prototype[method] = async function (path, configOrCb, cb) {
+    return await this.read(path, method, configOrCb, cb);
 });
 
 // Creates write requests
-["post", "put", "patch"].forEach((method) => Nexis.prototype[method] = function (path, body, configOrCb, cb) {
-    return new Promise((resolve, reject) => {
-        // Auto encodes body and configures content type and length
-        //      Based off the body param
-        const [data, headers] = encodeConfigBody(body);
-        
-        // Resolve callback and merge configs
-        let config = deepMerge(defaults.config(), { headers });
-        config = deepMerge(config, this.getConfig());
-        if (typeof configOrCb === "function") {
-            cb = configOrCb;
-        } else if (configOrCb) {
-            config = deepMerge(config, configOrCb);
-        }
-
-        const url = new URL(path, this.getBaseURL());
-        const req = protocols[url.protocol].request({
-            protocol: url.protocol,
-            hostname: url.hostname,
-            port: url.port,
-            path: url.pathname + url.search,
-            method,
-            ...config
-        }, (res) => {
-            res.data = "";
-
-            const chunks = [];
-            res.on("data", (chunk) => {
-                if (typeof chunk === "string") {
-                    res.data += chunk;
-                    return;
-                }
-
-                chunks.push(chunk);
-            });
-
-            res.on("end", () => {
-                // Combines chunks
-                if (chunks.length > 0)
-                    res.data = Buffer.concat(chunks).toString();
-                
-                // Converts response data based off headers
-                //      Parse json object or construct URLSearchParams
-                res.data = decodeData(res.data, res.headers["content-type"]);
-                
-                cb && cb(res);
-                resolve(res);
-            });
-        });
-
-        req.on("error", (err) => {
-            req.destroy(err);
-            cb && cb(defaults.res(), err);
-            reject(err);
-        });
-
-        // Coverts data into Readable Stream
-        //      Feeds data into writable stream "req"
-        const readData = Readable.from(data);
-        readData.pipe(req);
-        readData.on("error", (err) => {
-            req.destroy(err);
-            cb && cb(defaults.res(), err);
-            reject(err);
-        });
-    });
+["post", "put", "patch"].forEach((method) => Nexis.prototype[method] = async function (path, body, configOrCb, cb) {
+    return await this.write(path, method, body, configOrCb, cb);
 });
 
 exports = module.exports = Nexis;

--- a/tests/Nexis.test.js
+++ b/tests/Nexis.test.js
@@ -71,6 +71,8 @@ describe("Nexis instance", () => {
     });
 
     it("should have request methods", () => {
+        assert.strictEqual(typeof client.read, "function");
+        assert.strictEqual(typeof client.write, "function");
         assert.strictEqual(typeof client.get, "function");
         assert.strictEqual(typeof client.delete, "function");
         assert.strictEqual(typeof client.post, "function");

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -115,6 +115,19 @@ describe("requests on test server", () => {
     });
     
     const client = nexis.create({ port });
+
+    it("read get request", async () => {
+        const response = await client.read("/", "get");
+        assert.strictEqual(response.statusCode, 200);
+        assert.strictEqual(response.data, "Hello, World!");
+    });
+
+    it("write post request", async () => {
+        const data = { message: "Hello, World!" };
+        const response = await client.write("/", "post", data);
+        assert.strictEqual(response.statusCode, 200);
+        assert.deepStrictEqual(response.data, data);
+    });
     
     it("basic get request promise response", async () => {
         const response = await client.get("/");


### PR DESCRIPTION
This pull request is to merge the branch `14-refactor-remove-repetitive-code-from-readwrite-methods` into the `main` branch.

Removed the repetitive code across the read and write request methods. Created multiple private methods to the `Nexis` class & created `read` & `write` methods that use the private methods which perform the common processes while the methods themselves perform their unique processes in-between.