### PR TITLE
10-refactor-stream-data-via-pipeline-method

### DIFF
--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -1,4 +1,5 @@
 const { Readable } = require("node:stream");
+const { pipeline } = require("node:stream/promises");
 const http = require("node:http");
 const protocols = require("../protocols");
 const defaults = require("../defaults");
@@ -137,10 +138,8 @@ class Nexis {
 
             const req = this.#request(path, method, config, ...this.#generateHandlers(resolve, reject, callback));
 
-            const readData = Readable.from(data);
-            readData.pipe(req);
-            readData.on("error", (err) => {
-                req.destroy(err);
+            // Feeds data to req writable stream
+            pipeline(Readable.from(data), req).catch((err) => {
                 callback && callback(defaults.res(), err);
                 reject(err);
             });


### PR DESCRIPTION
This pull request is to merge the branch `10-refactor-stream-data-via-pipeline-method` into the `main` branch.

Uses the promised based `pipeline` `Stream` method rather than the inbulit `pipe` method as it has better error handling, automatically `destroys` related `streams` to avoid memory leakage and allows to easily setup a `transformer` in the future.