### PR TITLE
27-fix-invalid-deep-merge

### DIFF
--- a/lib/utils/deepMerge.js
+++ b/lib/utils/deepMerge.js
@@ -5,7 +5,7 @@ function deepMerge(object1, object2) {
         Object.keys(object2).forEach((property) => {
             // Recursion to merge deeper object
             if (typeof object2[property] === "object") {
-                object1[property] = {};
+                object1[property] = typeof object1[property] === "object" ? object1[property] : {};
                 object1[property] = deepMerge(object1[property], object2[property]);
                 return;
             }

--- a/tests/deepMerge.test.js
+++ b/tests/deepMerge.test.js
@@ -11,8 +11,15 @@ describe("config merger", () => {
         const config1 = { port: 3000, headers: { "content-type": "application/json" }};
         const config2 = { timeout: 10000, headers: { "content-type": "text/plain", "content-length": Buffer.byteLength("Hello") }};
 
-        const expected = { port: 3000, timeout: 10000, headers: { "content-type": "text/plain", "content-length": Buffer.byteLength("Hello") }};
+        const expected1 = { port: 3000, timeout: 10000, headers: { "content-type": "text/plain", "content-length": Buffer.byteLength("Hello") }};
         
-        assert.deepStrictEqual(deepMerge(config1, config2), expected);
+        assert.deepStrictEqual(deepMerge(config1, config2), expected1);
+
+        const config3 = { headers: { accept: "*/*" } };
+        const config4 = { headers: { "content-type": "text/plain" }};
+
+        const expected2 = { headers: { ...config3.headers, ...config4.headers } };
+
+        assert.deepStrictEqual(deepMerge(config3, config4), expected2);
     });
 });


### PR DESCRIPTION
This pull request is to merge the branch `27-fix-invalid-deep-merge` into the `main` branch.

Fixed the until `deepMerge` method to only assign property of empty object if currently value ins't already a object, to avoid the entire property being overriden.