### PR TITLE
25-feat-automatic-date-construction

### DIFF
--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -80,6 +80,8 @@ class Nexis {
     }
 
     #request(path, method, config, onResolve, onReject) {
+        config = deepMerge({ headers: { date: new Date().toUTCString() }}, config);
+        
         const url = new URL(path, this.#baseURL);
         const req = protocols[url.protocol].request({
             protocol: url.protocol,

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -240,10 +240,17 @@ describe("requests on test server", () => {
     });
 
     it("get date request", async () => {
-        const response = await client.get("/date");
-        assert.strictEqual(response.statusCode, 200);
-        assert.strictEqual(typeof response.data, "string");
-        assert.strictEqual(response.data !== "", true, "Expected non empty string");
+        // Auto generate date
+        const autoResponse = await client.get("/date");
+        assert.strictEqual(autoResponse.statusCode, 200);
+        assert.strictEqual(typeof autoResponse.data, "string");
+        assert.strictEqual(autoResponse.data !== "", true, "Expected non empty string");
+
+        // Manuelly assign date
+        const date = new Date("April 11, 2026 15:10:00").toUTCString();
+        const manuelResponse = await client.get("/date", { headers: { date }});
+        assert.strictEqual(manuelResponse.statusCode, 200);
+        assert.strictEqual(manuelResponse.data, date);
     });
 
     it("get redirect request", async () => {


### PR DESCRIPTION
This pull request is to merge the branch `25-feat-automatic-date-construction` into the `main` branch.

Added the automatic construction of `date` property in the `headers`. Only if it isn't manually parsed through the `config`.