### PR TITLE
24-feat-implement-authorization-json-parsing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,6 +58,16 @@ export type decodeData = (data: string, contentType: string) => string | object 
 export const decodeData: decodeData;
 
 /**
+ * Used to format json auth credentials to string, following the scheme format.
+ * The scheme is defined in the `scheme` property of the `auth` param. Supported scheme formates include `basic`, `bearer` & `digest`.
+ * - `Basic` scheme requires `username` & `password` params.
+ * - `Bearer` scheme requires `token` param.
+ * - `Digest` scheme loops through every provided param.
+ */
+export type authFormatter = (auth: { scheme: "basic" | "bearer" | "digest"; token?: string; username?: string; password?: string; [key: string]: string }, onReject: NexisCallback) => string;
+export const authFormatter: authFormatter;
+
+/**
  * Creates a `Nexis` instance that uses the `node:http` & `node:https` libraries to make http(s) request and receive responses.
  * Simplifys making requests by auto configurating, encoding and decoding data, and sets up default event handlers and values.
  * Additionally, provides many options to handle a response or error.
@@ -186,5 +196,6 @@ const nexis: NexisFactory & {
     deepMerge: deepMerge;
     encodeConfigBody: encodeConfigBody;
     decodeData: decodeData;
+    authFormatter: authFormatter;
 };
 export default nexis;

--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -6,6 +6,7 @@ const defaults = require("../defaults");
 const deepMerge = require("../utils/deepMerge");
 const encodeConfigBody = require("../utils/encodeConfigBody");
 const decodeData = require("../utils/decodeData");
+const authFormatter = require("../utils/authFormatter");
 
 class Nexis {
     #baseURL = defaults.baseURL;
@@ -81,6 +82,11 @@ class Nexis {
 
     #request(path, method, config, onResolve, onReject) {
         config = deepMerge({ headers: { date: new Date().toUTCString() }}, config);
+
+        // Formats authorization if in json form
+        const newAuth = authFormatter(config?.headers?.authorization, onReject);
+        if (newAuth)
+            config.headers.authorization = newAuth;
         
         const url = new URL(path, this.#baseURL);
         const req = protocols[url.protocol].request({

--- a/lib/nexis.js
+++ b/lib/nexis.js
@@ -5,6 +5,7 @@ const protocols = require("./protocols");
 const deepMerge = require("./utils/deepMerge");
 const encodeConfigBody = require("./utils/encodeConfigBody");
 const decodeData = require("./utils/decodeData");
+const authFormatter = require("./utils/authFormatter");
 
 const nexis = createClient({ baseURL: defaults.baseURL, ...defaults.config() });
 
@@ -16,5 +17,6 @@ nexis.protocols = protocols;
 nexis.deepMerge = deepMerge;
 nexis.encodeConfigBody = encodeConfigBody;
 nexis.decodeData = decodeData;
+nexis.authFormatter = authFormatter;
 
 exports = module.exports = nexis;

--- a/lib/utils/authFormatter.js
+++ b/lib/utils/authFormatter.js
@@ -1,0 +1,33 @@
+const defaults = require("../defaults");
+
+exports = module.exports = authFormatter;
+
+function authFormatter(auth, onReject) {
+    // Only formats if is an object
+    if (!auth || typeof auth !== "object") 
+        return auth;
+
+    const { scheme, ...credentials } = auth;
+    switch(scheme.toLowerCase()) {
+        case "basic":
+            const { username, password } = credentials;
+            return `Basic ${btoa(`${username}:${password}`)}`;
+
+        case "bearer":
+            return `Bearer ${credentials.token}`;
+
+        case "digest":
+            let string = "Digest ";
+            const entries = Object.entries(credentials);
+            for (let i = 0; i < entries.length; i++) {
+                const [key, value] = entries[i];
+                string += `${key}=${value},`;
+            }
+
+            // Removes the comma at the end
+            return string.slice(0, string.length - 1);
+
+        default:
+            onReject(defaults.res(), new TypeError("Invalid Auth Scheme"));
+    }
+}

--- a/tests/authFormatter.test.js
+++ b/tests/authFormatter.test.js
@@ -1,0 +1,38 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const authFormatter = require("../lib/utils/authFormatter");
+
+describe("Auth Formatter", () => {
+    it("should be a function", () => {
+        assert.strictEqual(typeof authFormatter, "function");
+    });
+
+    it("should format basic scheme", () => {
+        const auth = { scheme: "basic", username: "test", password: "1234" };
+        assert.strictEqual(authFormatter(auth), `Basic ${btoa(`${auth.username}:${auth.password}`)}`);
+    });
+
+    it("should format bearer scheme", () => {
+        const auth = { scheme: "bearer", token: "bfhwf7yr37rd" };
+        assert.strictEqual(authFormatter(auth), `Bearer ${auth.token}`);
+    });
+
+    it("should format digest scheme", () => {
+        const auth = { scheme: "digest", username: "test", realm: "test-realm" };
+        assert.strictEqual(authFormatter(auth), `Digest username=${auth.username},realm=${auth.realm}`);
+    });
+
+    it("shouldn't format non json auth", () => {
+        const auth = "Bearer bfhwf7yr37rd";
+        assert.strictEqual(authFormatter(auth), auth);
+    });
+
+    it("should reject invalid auth scheme", () => {
+        const auth = { scheme: "invalid" };
+        assert.rejects(
+            () => new Promise((resolve, reject) => authFormatter(auth, (res, err) => reject(err))),
+            (err) => err instanceof TypeError && err.message.includes("Invalid Auth Scheme"),
+            "should reject invalid auth scheme"
+        );
+    });
+});

--- a/tests/cjs-export.test.js
+++ b/tests/cjs-export.test.js
@@ -1,7 +1,7 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
 const nexis = require("../index");
-const { Nexis, defaults, protocols, deepMerge, encodeConfigBody, decodeData } = require("../index");
+const { Nexis, defaults, protocols, deepMerge, encodeConfigBody, decodeData, authFormatter } = require("../index");
 
 describe("cjs exports", () => {
     it("export default nexis interface", () => {
@@ -31,5 +31,9 @@ describe("cjs exports", () => {
 
     it("decodeData function", () => {
         assert.strictEqual(typeof decodeData, "function");
+    });
+
+    it("authFormatter function", () => {
+        assert.strictEqual(typeof authFormatter, "function");
     });
 });

--- a/tests/esm-export.test.mjs
+++ b/tests/esm-export.test.mjs
@@ -31,4 +31,8 @@ describe("esm exports", () => {
     it("decodeData function", () => {
         assert.strictEqual(typeof nexis.decodeData, "function");
     });
+
+    it("authFormatter function", () => {
+        assert.strictEqual(typeof nexis.authFormatter, "function");
+    });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -28,7 +28,7 @@ describe("requests on test server", () => {
 
                 // Get auth request
                 if (req.url === "/auth" && req.method === "GET") {
-                    res.writeHead(200, { "content-type": "application/json" });
+                    res.writeHead(200, { "content-type": "text/plain" });
                     res.end(req.headers.authorization);
                     return;
                 }
@@ -232,11 +232,42 @@ describe("requests on test server", () => {
         assert.deepStrictEqual(response.data, { [key]: value });
     });
 
-    it("get authorization request", async () => {
-        const authroization = { username: "Test", password: "1234" };
-        const response = await client.get("/auth", { headers: { authroization } });
+    it("basic authorization request", async () => {
+        const authorization = { scheme: "basic", username: "test", password: "1234" };
+        const { username, password } = authorization;
+        const response = await client.get("/auth", { headers: { authorization }});
         assert.strictEqual(response.statusCode, 200);
-        assert.deepStrictEqual(response.data, authroization);
+        assert.strictEqual(response.data, `Basic ${btoa(`${username}:${password}`)}`);
+    });
+
+    it("bearer authorization request", async () => {
+        const authorization = { scheme: "bearer", token: "hfghe7373rdgf" };
+        const response = await client.get("/auth", { headers: { authorization }});
+        assert.strictEqual(response.statusCode, 200);
+        assert.strictEqual(response.data, `Bearer ${authorization.token}`);
+    });
+
+    it("digest authorization request", async () => {
+        const authorization = { scheme: "digest", username: "test", realm: "test" };
+        const response = await client.get("/auth", { headers: { authorization } });
+        assert.strictEqual(response.statusCode, 200);
+        assert.deepStrictEqual(response.data, "Digest username=test,realm=test");
+    });
+
+    it("unformatted bearer request", async () => {
+        const authorization = "Bearer hfghe7373rdgf";
+        const response = await client.get("/auth", { headers: { authorization }});
+        assert.strictEqual(response.statusCode, 200);
+        assert.strictEqual(response.data, authorization);
+    });
+
+    it("invalid authorization scheme error thrown", () => {
+        const authorization = { scheme: "invalid", username: "test" };
+        assert.rejects(
+            async () => await client.get("/auth", { headers: { authorization }}),
+            (err) => err instanceof TypeError && err.message.includes("Invalid Auth Scheme"),
+            "should reject invalid auth scheme"
+        );
     });
 
     it("get date request", async () => {


### PR DESCRIPTION
This pull request is to merge the branch `24-feat-implement-authorization-json-parsing` into the `main` branch.

Implemented the ability for the user to provide the `headers` `authorization` param in `json` form, by implementing a utility function to format the `credentials` based off the specified `scheme`. The `authorization` param isn't formatted if it isn't in `json` form.

The supported auth `schemes` include:
- `Basic`: requires `username` & `password` params.
- `Bearer`: requires `token` param.
- `Digest`: loops through every provided param.