### PR TITLE
26-feat-automatically-handle-redirects

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ export type NexisCallback = (res: http.IncomingMessage, err?: Error) => void;
 /**
  * Configuration options for a `Nexis` instance.
  */
-export type NexisConfig = http.RequestOptions & { baseURL: string | URL }
+export type NexisConfig = http.RequestOptions & { baseURL: string | URL; maxRedirects?: number }
 
 /**
  * Defines the default values.
@@ -25,6 +25,7 @@ export type defaults = {
     config: () => ({ 
         port: 80,
         timeout: 10000,
+        maxRedirects: 0
     }),
     res: () => ({ data: null })
 }

--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -80,7 +80,7 @@ class Nexis {
         return [handleResolve, handleReject];
     }
 
-    #request(path, method, config, onResolve, onReject) {
+    #request(path, method, config, onRequest, onResolve, onReject) {
         config = deepMerge({ headers: { date: new Date().toUTCString() }}, config);
 
         // Formats authorization if in json form
@@ -111,6 +111,12 @@ class Nexis {
                 // Converts response data based off headers
                 //      Parse json object or construct URLSearchParams
                 res.data = decodeData(res.data, res.headers["content-type"]);
+
+                // Handle redirect
+                if (config?.maxRedirects > 0 && res.statusCode === 301 && res.headers.location) {
+                    const { maxRedirects, ...other } = config;
+                    return this.#request(res.headers.location, method, { ...other, maxRedirects: maxRedirects - 1 }, onRequest, onResolve, onReject);
+                }
                 
                 onResolve(res);
             });
@@ -121,7 +127,7 @@ class Nexis {
             onReject(defaults.res(), err);
         });
 
-        return req;
+        onRequest(req);
     }
 
     read(path, method, configOrCb, cb) {
@@ -129,9 +135,9 @@ class Nexis {
             // Resolve callback & merge configs
             const [config, callback] = this.#handleCallbackConfig(configOrCb, cb);
 
-            const req = this.#request(path, method, config, ...this.#generateHandlers(resolve, reject, callback));
+            const handleRequest = (req) => req.end();
 
-            req.end();
+            this.#request(path, method, config, handleRequest, ...this.#generateHandlers(resolve, reject, callback));
         });
     }
 
@@ -144,13 +150,15 @@ class Nexis {
             const [data, headers] = encodeConfigBody(body);
             config = deepMerge({ headers }, config);
 
-            const req = this.#request(path, method, config, ...this.#generateHandlers(resolve, reject, callback));
+            const handleRequest = (req) => {
+                // Feeds data to req writable stream
+                pipeline(Readable.from(data), req).catch((err) => {
+                    callback && callback(defaults.res(), err);
+                    reject(err);
+                });
+            }
 
-            // Feeds data to req writable stream
-            pipeline(Readable.from(data), req).catch((err) => {
-                callback && callback(defaults.res(), err);
-                reject(err);
-            });
+            this.#request(path, method, config, handleRequest, ...this.#generateHandlers(resolve, reject, callback));
         });
     }
 }

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -3,6 +3,7 @@ const defaults = {
     config: () => ({ 
         port: 80,
         timeout: 10000,
+        maxRedirects: 0
     }),
     res: () => ({ data: null })
 }

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -47,8 +47,13 @@ describe("requests on test server", () => {
                     return;
                 }
                 if (req.url === "/new-resource" && req.method === "GET") {
+                    res.writeHead(301, { location: "/newer-resource" });
+                    res.end();
+                    return;
+                }
+                if (req.url === "/newer-resource" && req.method === "GET") {
                     res.writeHead(200, { "content-type": "text/plain" });
-                    res.end("New Resource");
+                    res.end("Newer Resource");
                     return;
                 }
 
@@ -140,7 +145,7 @@ describe("requests on test server", () => {
         server.close();
     });
     
-    const client = nexis.create({ port });
+    const client = nexis.create({ port, maxRedirects: 2 });
 
     it("read get request", async () => {
         const response = await client.read("/", "get");
@@ -285,8 +290,18 @@ describe("requests on test server", () => {
     });
 
     it("get redirect request", async () => {
-        const response = await client.get("/resource");
-        assert.strictEqual(response.statusCode, 200);
-        assert.strictEqual(response.data, "New Resource");
+        const redirectResponse = await client.get("/resource");
+        assert.strictEqual(redirectResponse.statusCode, 200, "should redirect to /newer-resource");
+        assert.strictEqual(redirectResponse.data, "Newer Resource", "should redirect to /newer-resource");
+
+        // Checks that the maxRedirect config isn't updated by reference
+        //      When the request subtracts it and passes it as the config to the next request
+        assert.strictEqual(client.getConfig().maxRedirects, 2, "maxRedirects should remain as set");
+
+        // Shouldn't redirect when set to 0
+        client.setConfig({ port, maxRedirects: 0 });
+        const nonRedirectResponse = await client.get("/resource");
+        assert.strictEqual(nonRedirectResponse.statusCode, 301, "shouldn't redirect when set to 0");
+        assert.strictEqual(nonRedirectResponse.headers.location, "/new-resource", "shouldn't redirect when set to 0");
     });
 });


### PR DESCRIPTION
This pull request is to merge the branch `26-feat-automatically-handle-redirects` into the `main` branch.

Implements automatic handling of redirects if `response` is status `301` and `headers` includes `location` param. Added `maxRedirects` param to `NexisConfig` that gives control on how many redirects the client should automatically handle, set as 0 by default.

Had to implement `request` handler as the `request` couldn't be returned to the `read` & `write` methods due to the chaining requests so a `handleRequest` function is defined and passed through the `request` method and is called to handle `request`. So, for the `read` method it just `ends` the `request` while the `write` method `streams` the `body` data.

<img width="908" height="202" alt="image" src="https://github.com/user-attachments/assets/5d58f814-7f28-4305-97a1-5077e5bf4e2f" />

<img width="887" height="401" alt="image" src="https://github.com/user-attachments/assets/a9fab66d-e5a8-4c5f-80f9-5ca525ad2c60" />