### PR TITLE
4-fix-use-header-getter-methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,20 @@ export type NexisCallback = (res: http.IncomingMessage, err?: Error) => void;
 export type NexisConfig = http.RequestOptions & { baseURL: string | URL; maxRedirects?: number }
 
 /**
+ * A class that extends off the `http.IncomingMessage` class and implements custom `header` methods.
+ * @class
+ * @extends {http.IncomingMessage}
+ */
+export class NexisIncomingMessage extends http.IncomingMessage {
+    constructor(socket: net.Socket);
+    
+    getHeader(name: string): string | string[];
+    getHeaders(names: string[]): http.IncomingHttpHeaders;
+    getHeaderNames(): string[];
+    hasHeader(name: string): boolean;
+}
+
+/**
  * Defines the default values.
  */
 export type defaults = {
@@ -167,7 +181,7 @@ export class Nexis {
 
     Agent: http.Agent;
     ClientRequest: http.ClientRequest;
-    IncomingMessage: http.IncomingMessage;
+    IncomingMessage: NexisIncomingMessage;
     OutgoingMessage: http.OutgoingMessage;
     METHODS: typeof http.METHODS;
     STATUS_CODES: typeof http.STATUS_CODES;

--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -1,12 +1,12 @@
 const { Readable } = require("node:stream");
 const { pipeline } = require("node:stream/promises");
-const http = require("node:http");
 const protocols = require("../protocols");
 const defaults = require("../defaults");
 const deepMerge = require("../utils/deepMerge");
 const encodeConfigBody = require("../utils/encodeConfigBody");
 const decodeData = require("../utils/decodeData");
 const authFormatter = require("../utils/authFormatter");
+const http = require("../utils/header-methods");
 
 class Nexis {
     #baseURL = defaults.baseURL;
@@ -110,12 +110,12 @@ class Nexis {
 
                 // Converts response data based off headers
                 //      Parse json object or construct URLSearchParams
-                res.data = decodeData(res.data, res.headers["content-type"]);
+                res.data = decodeData(res.data, res.getHeader("content-type"));
 
                 // Handle redirect
-                if (config?.maxRedirects > 0 && res.statusCode === 301 && res.headers.location) {
+                if (config?.maxRedirects > 0 && res.statusCode === 301 && res.getHeader("location")) {
                     const { maxRedirects, ...other } = config;
-                    return this.#request(res.headers.location, method, { ...other, maxRedirects: maxRedirects - 1 }, onRequest, onResolve, onReject);
+                    return this.#request(res.getHeader("location"), method, { ...other, maxRedirects: maxRedirects - 1 }, onRequest, onResolve, onReject);
                 }
                 
                 onResolve(res);

--- a/lib/utils/header-methods.js
+++ b/lib/utils/header-methods.js
@@ -1,0 +1,29 @@
+const http = require("node:http");
+
+exports = module.exports = http;
+
+// Implements header methods that are case-insensitive into instances of IncomingMessage 
+//      which is received in the callback param in http.request method
+http.IncomingMessage.prototype.getHeader = function getHeader(name) {
+    return this.headers[name.toLowerCase()];
+}
+
+http.IncomingMessage.prototype.getHeaders = function getHeaders(names) {
+    const headers = {};
+    for (let i = 0; i < names.length; i++) {
+        const value = this.getHeader(names[i]);
+        if (value) {
+            headers[names[i].toLowerCase()] = value;
+        }
+    }
+
+    return headers;
+}
+
+http.IncomingMessage.prototype.getHeaderNames = function getHeaderNames() {
+    return Object.keys(this.headers);
+}
+
+http.IncomingMessage.prototype.hasHeader = function hasHeader(name) {
+    return Object.hasOwn(this.headers, name.toLowerCase());
+}

--- a/tests/Nexis.test.js
+++ b/tests/Nexis.test.js
@@ -95,5 +95,11 @@ describe("Nexis instance", () => {
         assert.deepStrictEqual(client.maxHeaderSize, http.maxHeaderSize);
         assert.deepStrictEqual(client.validateHeaderName, http.validateHeaderName);
         assert.deepStrictEqual(client.validateHeaderValue, http.validateHeaderValue);
+
+        // Implemented custom header getter methods
+        assert.strictEqual(typeof client.IncomingMessage.prototype.getHeader, "function", "inherited IncomingMessage class should have custom getHeader method");
+        assert.strictEqual(typeof client.IncomingMessage.prototype.getHeaders, "function", "inherited IncomingMessage class should have custom getHeaders method");
+        assert.strictEqual(typeof client.IncomingMessage.prototype.getHeaderNames, "function", "inherited IncomingMessage class should have custom getHeaderNames method");
+        assert.strictEqual(typeof client.IncomingMessage.prototype.hasHeader, "function", "inherited IncomingMessage class should have custom hasHeader method");
     });
 });

--- a/tests/header-methods.test.js
+++ b/tests/header-methods.test.js
@@ -1,0 +1,28 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const http = require("node:http");
+const customHttp = require("../lib/utils/header-methods");
+
+describe("custom IncomingMessage header methods", () => {
+    it("should be built off http module", () => {
+        Object.entries(http).forEach(([key, value]) => {
+            assert.deepStrictEqual(customHttp[key], value);
+        });
+    });
+
+    it("should have getHeader method", () => {
+        assert.strictEqual(typeof customHttp.IncomingMessage.prototype.getHeader, "function");
+    });
+
+    it("should have getHeaders method", () => {
+        assert.strictEqual(typeof customHttp.IncomingMessage.prototype.getHeaders, "function");
+    });
+
+    it("should have getHeaderNames method", () => {
+        assert.strictEqual(typeof customHttp.IncomingMessage.prototype.getHeaderNames, "function");
+    });
+
+    it("should have hasHeader method", () => {
+        assert.strictEqual(typeof customHttp.IncomingMessage.prototype.hasHeader, "function");
+    });
+});

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -57,6 +57,13 @@ describe("requests on test server", () => {
                     return;
                 }
 
+                // Get case-insenitive request
+                if (req.url === "/case" && req.method === "GET") {
+                    res.writeHead(200, { "Content-Type": "application/json" });
+                    res.end(JSON.stringify({ message: "Hello" }));
+                    return;
+                }
+
                 // Post object request
                 if (req.url === "/" && req.method === "POST") {
                     res.writeHead(200, { "content-type": "application/json" });
@@ -303,5 +310,28 @@ describe("requests on test server", () => {
         const nonRedirectResponse = await client.get("/resource");
         assert.strictEqual(nonRedirectResponse.statusCode, 301, "shouldn't redirect when set to 0");
         assert.strictEqual(nonRedirectResponse.headers.location, "/new-resource", "shouldn't redirect when set to 0");
+    });
+
+    it("get request case-insenitive", async () => {
+        const response = await client.get("/case");
+        assert.strictEqual(response.statusCode, 200);
+        assert.deepStrictEqual(response.data, { message: "Hello" });
+
+        // Test getHeaders method
+        assert.deepStrictEqual(
+            response.getHeaders(["content-type", "connection"]), 
+            { "content-type": "application/json", "connection": "keep-alive" },
+            "response should have getHeaders method"
+        );
+
+        // Test getHeaderNames method
+        assert.deepStrictEqual(
+            response.getHeaderNames(),
+            ["content-type", "date", "connection", "keep-alive", "transfer-encoding"],
+            "response should have getHeaderNames method"
+        );
+
+        // Test hasHeader method
+        assert.strictEqual(response.hasHeader("Content-Type"), true, "response should have hasHeader method");
     });
 });


### PR DESCRIPTION
This pull request is to merge the branch `4-fix-use-header-getter-methods` into the `main` branch.

Implements custom `header` methods into the `http.IncomingMessage` class that are case-insensitive.