### PR TITLE
35-fix-set-timeout-and-create-handler

### DIFF
--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -152,10 +152,13 @@ class Nexis {
     });
 
     req.on("timeout", () => {
-      const err = new Error(`Socket Connection Timeout: ${config.timeout}ms Path: ${req.path}`, { 
-        cause: "The server didn't respond before the timeout", 
-        code: "ERR_HTTP_REQUEST_TIMEOUT"
-      });
+      const err = new Error(
+        `Socket Connection Timeout: ${config.timeout}ms Path: ${req.path}`,
+        {
+          cause: "The server didn't respond before the timeout",
+          code: "ERR_HTTP_REQUEST_TIMEOUT",
+        },
+      );
       req.destroy(err);
       onReject(defaults.res(), err);
     });

--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -151,6 +151,15 @@ class Nexis {
       onReject(defaults.res(), err);
     });
 
+    req.on("timeout", () => {
+      const err = new Error(`Socket Connection Timeout: ${config.timeout}ms Path: ${req.path}`, { 
+        cause: "The server didn't respond before the timeout", 
+        code: "ERR_HTTP_REQUEST_TIMEOUT"
+      });
+      req.destroy(err);
+      onReject(defaults.res(), err);
+    });
+
     onRequest(req);
   }
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -390,8 +390,10 @@ describe("requests on test server", () => {
   it("get timeout request", () => {
     assert.rejects(
       async () => await client.get("/timeout", { timeout: 1 }),
-      (err) => err instanceof Error && err.message.includes("Socket Connection Timeout"),
-      "should reject timeout error"
+      (err) =>
+        err instanceof Error &&
+        err.message.includes("Socket Connection Timeout"),
+      "should reject timeout error",
     );
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -65,6 +65,7 @@ describe("requests on test server", () => {
 
         // Get timeout request
         if (req.url === "/timeout" && req.method === "GET") {
+          /* eslint no-empty: "off" */
           for (let i = 0; i < 100; i++) {}
           res.writeHead(200);
           res.end();

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -63,6 +63,14 @@ describe("requests on test server", () => {
           return;
         }
 
+        // Get timeout request
+        if (req.url === "/timeout" && req.method === "GET") {
+          for (let i = 0; i < 100; i++) {}
+          res.writeHead(200);
+          res.end();
+          return;
+        }
+
         // Post object request
         if (req.url === "/" && req.method === "POST") {
           res.writeHead(200, { "content-type": "application/json" });
@@ -376,6 +384,14 @@ describe("requests on test server", () => {
       response.hasHeader("Content-Type"),
       true,
       "response should have hasHeader method",
+    );
+  });
+
+  it("get timeout request", () => {
+    assert.rejects(
+      async () => await client.get("/timeout", { timeout: 1 }),
+      (err) => err instanceof Error && err.message.includes("Socket Connection Timeout"),
+      "should reject timeout error"
     );
   });
 });


### PR DESCRIPTION
This pull request is to merge the branch `35-fix-set-timeout-and-create-handler` into the `main` branch.

Created timeout handler that constructs an `Error`, destroys the `request` object and rejects a default `response` value and the `Error`.