### PR TITLE
8-feat-creation-of-custom-event-handlers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import * as http from "node:http";
 import * as https from "node:https";
+import EventEmitter from "node:events";
 import { Stream } from "node:stream";
 
 /**
@@ -15,9 +16,20 @@ export type NexisBody =
   | URLSearchParams;
 
 /**
+ * A `Nexis` error with `request` and `response` objects attached.
+ */
+export type NexisError = Error & {
+  req: http.ClientRequest;
+  res: http.IncomingMessage;
+};
+
+/**
  * A `Nexis` callback function to handle response and error.
  */
-export type NexisCallback = (res: http.IncomingMessage, err?: Error) => void;
+export type NexisCallback = (
+  res: http.IncomingMessage,
+  err?: NexisError,
+) => void;
 
 /**
  * Configuration options for a `Nexis` instance.
@@ -52,6 +64,7 @@ export type defaults = {
     maxRedirects: 0;
   };
   res: () => { data: null };
+  req: () => {};
 };
 export const defaults: defaults;
 
@@ -102,9 +115,20 @@ export type authFormatter = (
     password?: string;
     [key: string]: string;
   },
-  onReject: NexisCallback,
+  onReject: (err: TypeError) => void,
 ) => string;
 export const authFormatter: authFormatter;
+
+/**
+ * Defines `Nexis` events and their arguments.
+ */
+export interface NexisEvents {
+  request: [req: http.ClientRequest];
+  data: [data: string];
+  redirect: [res: http.IncomingMessage, config: NexisConfig];
+  response: [res: http.IncomingMessage];
+  error: [err: NexisError];
+}
 
 /**
  * Creates a `Nexis` instance that uses the `node:http` & `node:https` libraries to make http(s) request and receive responses.
@@ -132,8 +156,9 @@ export const authFormatter: authFormatter;
  *      }
  *
  * @class
+ * @extends {EventEmitter}
  */
-export class Nexis {
+export class Nexis extends EventEmitter<NexisEvents> {
   /**
    * Creates a `Nexis` instance that uses the `node:http` & `node:https` libraries to make http(s) request and receive responses.
    * Simplifys making requests by auto configurating, encoding and decoding data, and sets up default event handlers and values.
@@ -160,6 +185,7 @@ export class Nexis {
    *      }
    *
    * @class
+   * @extends {EventEmitter}
    */
   constructor(config: NexisConfig);
 

--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -1,5 +1,6 @@
 const { Readable } = require("node:stream");
 const { pipeline } = require("node:stream/promises");
+const EventEmitter = require("node:events");
 const protocols = require("../protocols");
 const defaults = require("../defaults");
 const deepMerge = require("../utils/deepMerge");
@@ -8,11 +9,13 @@ const decodeData = require("../utils/decodeData");
 const authFormatter = require("../utils/authFormatter");
 const http = require("../utils/header-methods");
 
-class Nexis {
+class Nexis extends EventEmitter {
   #baseURL = defaults.baseURL;
   #config = defaults.config();
 
   constructor(config) {
+    super();
+
     const { baseURL, ...otherConfig } = config;
 
     this.setBaseURL(baseURL);
@@ -79,23 +82,42 @@ class Nexis {
 
   #generateHandlers(resolve, reject, cb) {
     const handleResolve = (res) => {
+      this.emit("response", res);
       cb && cb(res);
       resolve(res);
     };
 
-    const handleReject = (res, err) => {
-      cb && cb(res, err);
-      reject(err);
+    const handleReject = (req, res, err) => {
+      if (req instanceof http.ClientRequest) req.destroy(err);
+      if (res instanceof http.IncomingMessage) res.destroy(err);
+
+      // Attach request and response objects to error
+      err.req = req;
+      err.res = res;
+
+      // Determines error handler
+      if (this.listenerCount("error") > 0) {
+        this.emit("error", err);
+      } else if (cb) {
+        cb(res, err);
+      } else {
+        reject(err);
+      }
     };
 
-    return [handleResolve, handleReject];
+    return {
+      onResolve: handleResolve,
+      onReject: handleReject,
+    };
   }
 
-  #request(path, method, config, onRequest, onResolve, onReject) {
+  #request(path, method, config, handlers) {
     config = deepMerge({ headers: { date: new Date().toUTCString() } }, config);
 
     // Formats authorization if in json form
-    const newAuth = authFormatter(config?.headers?.authorization, onReject);
+    const newAuth = authFormatter(config?.headers?.authorization, (err) => {
+      handlers.onReject(defaults.req(), defaults.res(), err);
+    });
     if (newAuth) config.headers.authorization = newAuth;
 
     const url = new URL(path, this.#baseURL);
@@ -120,6 +142,8 @@ class Nexis {
           // Combines chunks
           res.data = Buffer.concat(chunks).toString();
 
+          this.emit("data", res.data);
+
           // Converts response data based off headers
           //      Parse json object or construct URLSearchParams
           res.data = decodeData(res.data, res.getHeader("content-type"));
@@ -130,40 +154,48 @@ class Nexis {
             res.statusCode === 301 &&
             res.getHeader("location")
           ) {
+            this.emit("redirect", res, config);
             const { maxRedirects, ...other } = config;
             return this.#request(
               res.getHeader("location"),
               method,
               { ...other, maxRedirects: maxRedirects - 1 },
-              onRequest,
-              onResolve,
-              onReject,
+              handlers,
             );
           }
 
-          onResolve(res);
+          handlers.onResolve(res);
         });
       },
     );
 
-    req.on("error", (err) => {
-      req.destroy(err);
-      onReject(defaults.res(), err);
-    });
+    const error = (err) => {
+      handlers.onReject(req, defaults.res(), err);
+    };
+    req.on("error", error);
 
     req.on("timeout", () => {
-      const err = new Error(
-        `Socket Connection Timeout: ${config.timeout}ms Path: ${req.path}`,
-        {
-          cause: "The server didn't respond before the timeout",
-          code: "ERR_HTTP_REQUEST_TIMEOUT",
-        },
+      // Removes error event listener
+      //    To avoid timeout error being thrown again
+      //    When the request stream is destroyed by onReject handler
+      req.off("error", error);
+      req.on("error", () => null);
+
+      handlers.onReject(
+        req,
+        defaults.res(),
+        new Error(
+          `Socket Connection Timeout: ${config.timeout}ms Path: ${req.path}`,
+          {
+            cause: "The server didn't respond before the timeout",
+            code: "ERR_HTTP_REQUEST_TIMEOUT",
+          },
+        ),
       );
-      req.destroy(err);
-      onReject(defaults.res(), err);
     });
 
-    onRequest(req);
+    this.emit("request", req);
+    handlers.onRequest(req);
   }
 
   read(path, method, configOrCb, cb) {
@@ -171,15 +203,12 @@ class Nexis {
       // Resolve callback & merge configs
       const [config, callback] = this.#handleCallbackConfig(configOrCb, cb);
 
-      const handleRequest = (req) => req.end();
+      const handlers = this.#generateHandlers(resolve, reject, callback);
+      handlers.onRequest = function handleRequest(req) {
+        req.end();
+      };
 
-      this.#request(
-        path,
-        method,
-        config,
-        handleRequest,
-        ...this.#generateHandlers(resolve, reject, callback),
-      );
+      this.#request(path, method, config, handlers);
     });
   }
 
@@ -192,21 +221,15 @@ class Nexis {
       const [data, headers] = encodeConfigBody(body);
       config = deepMerge({ headers }, config);
 
-      const handleRequest = (req) => {
+      const handlers = this.#generateHandlers(resolve, reject, callback);
+      handlers.onRequest = function handleRequest(req) {
         // Feeds data to req writable stream
         pipeline(Readable.from(data), req).catch((err) => {
-          callback && callback(defaults.res(), err);
-          reject(err);
+          this.onReject(req, defaults.res(), err);
         });
       };
 
-      this.#request(
-        path,
-        method,
-        config,
-        handleRequest,
-        ...this.#generateHandlers(resolve, reject, callback),
-      );
+      this.#request(path, method, config, handlers);
     });
   }
 }

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -6,6 +6,7 @@ const defaults = {
     maxRedirects: 0,
   }),
   res: () => ({ data: null }),
+  req: () => ({}),
 };
 
 exports = module.exports = defaults;

--- a/lib/utils/authFormatter.js
+++ b/lib/utils/authFormatter.js
@@ -1,5 +1,3 @@
-const defaults = require("../defaults");
-
 exports = module.exports = authFormatter;
 
 function authFormatter(auth, onReject) {
@@ -28,6 +26,6 @@ function authFormatter(auth, onReject) {
       return string.slice(0, string.length - 1);
 
     default:
-      onReject(defaults.res(), new TypeError("Invalid Auth Scheme"));
+      onReject(new TypeError("Invalid Auth Scheme"));
   }
 }

--- a/tests/authFormatter.test.js
+++ b/tests/authFormatter.test.js
@@ -35,14 +35,25 @@ describe("Auth Formatter", () => {
 
   it("should reject invalid auth scheme", () => {
     const auth = { scheme: "invalid" };
-    assert.rejects(
-      () =>
-        new Promise((resolve, reject) =>
-          authFormatter(auth, (res, err) => reject(err)),
-        ),
-      (err) =>
-        err instanceof TypeError && err.message.includes("Invalid Auth Scheme"),
-      "should reject invalid auth scheme",
-    );
+    () =>
+      new Promise((resolve, reject) =>
+        authFormatter(auth, (err) => reject(err)),
+      ).catch(({ err: error }) => {
+        try {
+          assert.strictEqual(
+            error instanceof TypeError,
+            true,
+            "should reject TypeError",
+          );
+          assert.strictEqual(
+            error.message.includes("Invalid Auth Scheme"),
+            true,
+            "error should include 'Invalid Auth Scheme'",
+          );
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
   });
 });

--- a/tests/authFormatter.test.js
+++ b/tests/authFormatter.test.js
@@ -33,27 +33,26 @@ describe("Auth Formatter", () => {
     assert.strictEqual(authFormatter(auth), auth);
   });
 
-  it("should reject invalid auth scheme", () => {
+  it("should reject invalid auth scheme", { timeout: 500 }, (t, done) => {
     const auth = { scheme: "invalid" };
-    () =>
-      new Promise((resolve, reject) =>
-        authFormatter(auth, (err) => reject(err)),
-      ).catch(({ err: error }) => {
-        try {
-          assert.strictEqual(
-            error instanceof TypeError,
-            true,
-            "should reject TypeError",
-          );
-          assert.strictEqual(
-            error.message.includes("Invalid Auth Scheme"),
-            true,
-            "error should include 'Invalid Auth Scheme'",
-          );
-          done();
-        } catch (err) {
-          done(err);
-        }
-      });
+    new Promise((resolve, reject) =>
+      authFormatter(auth, reject),
+    ).catch((error) => {
+      try {
+        assert.strictEqual(
+          error instanceof TypeError,
+          true,
+          "should reject TypeError",
+        );
+        assert.strictEqual(
+          error.message.includes("Invalid Auth Scheme"),
+          true,
+          "error should include 'Invalid Auth Scheme'",
+        );
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert");
 const http = require("node:http");
 const Stream = require("node:stream");
 const nexis = require("../index");
+const defaults = require("../lib/defaults");
 
 describe("requests on test server", () => {
   let server;
@@ -15,7 +16,7 @@ describe("requests on test server", () => {
         chunks.push(chunk);
       });
 
-      req.on("end", () => {
+      req.on("end", async () => {
         if (chunks.length > 0) req.body = Buffer.concat(chunks).toString();
 
         // Basic get request
@@ -66,9 +67,17 @@ describe("requests on test server", () => {
         // Get timeout request
         if (req.url === "/timeout" && req.method === "GET") {
           /* eslint no-empty: "off" */
-          for (let i = 0; i < 100; i++) {}
+          async function timeout() {
+            return setTimeout(() => res.end(), 1);
+          }
+          await timeout();
+          return;
+        }
+
+        // Get events request
+        if (req.url === "/events" && req.method === "GET") {
           res.writeHead(200);
-          res.end();
+          res.end(req.getHeader("content-type"));
           return;
         }
 
@@ -167,6 +176,7 @@ describe("requests on test server", () => {
   });
 
   const client = nexis.create({ port, maxRedirects: 2 });
+  const timeout = 500; // Test timeout
 
   it("read get request", async () => {
     const response = await client.read("/", "get");
@@ -297,14 +307,27 @@ describe("requests on test server", () => {
     assert.strictEqual(response.data, authorization);
   });
 
-  it("invalid authorization scheme error thrown", () => {
+  it("invalid authorization scheme error thrown", { timeout }, (t, done) => {
     const authorization = { scheme: "invalid", username: "test" };
-    assert.rejects(
-      async () => await client.get("/auth", { headers: { authorization } }),
-      (err) =>
-        err instanceof TypeError && err.message.includes("Invalid Auth Scheme"),
-      "should reject invalid auth scheme",
-    );
+    client.get("/auth", { headers: { authorization } }).catch((error) => {
+      try {
+        assert.ok(error.req, "should provide request object");
+        assert.ok(error.res, "should provide response object");
+        assert.strictEqual(
+          error instanceof TypeError,
+          true,
+          "should reject TypeError",
+        );
+        assert.strictEqual(
+          error.message.includes("Invalid Auth Scheme"),
+          true,
+          "error message should include 'Invalid Auth Scheme'",
+        );
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
   });
 
   it("get date request", async () => {
@@ -388,13 +411,74 @@ describe("requests on test server", () => {
     );
   });
 
-  it("get timeout request", () => {
-    assert.rejects(
-      async () => await client.get("/timeout", { timeout: 1 }),
-      (err) =>
-        err instanceof Error &&
-        err.message.includes("Socket Connection Timeout"),
-      "should reject timeout error",
-    );
+  it("get timeout request", { timeout }, (t, done) => {
+    client.get("/timeout", { timeout: 1 }).catch((error) => {
+      try {
+        assert.ok(error.req, "should provide request object");
+        assert.ok(error.res, "should provide response object");
+        assert.strictEqual(error instanceof Error, true, "should reject Error");
+        assert.strictEqual(
+          error.message.includes("Socket Connection Timeout"),
+          true,
+          "error message should include 'Socket Connection Timeout'",
+        );
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+  });
+
+  it("get events request", { timeout }, (t, done) => {
+    const contentType = "Hello";
+    client.once("request", (req) => {
+      req.setHeader("content-type", contentType);
+    });
+    client.once("data", (data) => {
+      assert.strictEqual(data, contentType);
+    });
+    client.once("response", (res) => {
+      try {
+        assert.strictEqual(res.statusCode, 200);
+        assert.strictEqual(res.data, contentType);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+    client.get("/events");
+  });
+
+  it("get event redirect request", { timeout }, (t, done) => {
+    client.once("redirect", (res, config) => {
+      try {
+        assert.strictEqual(res.statusCode, 301);
+        assert.strictEqual(res.getHeader("location"), "/new-resource");
+        assert.strictEqual(config.port, port);
+        assert.strictEqual(config.maxRedirects, 1);
+      } catch (err) {
+        done(err);
+      }
+    });
+    client.once("response", () => {
+      done();
+    });
+    client.get("/resource", { maxRedirects: 1 });
+  });
+
+  it("get events error request", { timeout }, (t, done) => {
+    client.once("error", (error) => {
+      try {
+        assert.ok(error.req, "should provide request object");
+        assert.ok(error.res, "should provide response object");
+        assert.strictEqual(error instanceof Error, true, "should reject Error");
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    // Creates timeout error
+    client.get("/timeout", { timeout: 1 });
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -3,7 +3,6 @@ const assert = require("node:assert");
 const http = require("node:http");
 const Stream = require("node:stream");
 const nexis = require("../index");
-const defaults = require("../lib/defaults");
 
 describe("requests on test server", () => {
   let server;


### PR DESCRIPTION
This pull request is to merge the branch `8-feat-creation-of-custom-event-handlers` into the `main` branch.

Implemented the ability to create event handlers by extending the `Nexis` class of the `EventEmitter` class. Re-worked the error handling so that if an error occurs it is provided to the event listener. If there is no event listener then to the `callback` function and if there is no `callback` function it is rejected. Additionally, the `request` & `response` objects are attached to the `error` object for additional information.

If a timeout event occurs with the `request` object, before handling the `error` the listener removes the `error` event listener from the `request` object because it is called when the object is destroyed. Resulting in the timeout `error` being thrown twice.