### PR TITLE
41-fix-handle-header-validation-error-on-request

### DIFF
--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -121,53 +121,58 @@ class Nexis extends EventEmitter {
     if (newAuth) config.headers.authorization = newAuth;
 
     const url = new URL(path, this.#baseURL);
-    const req = protocols[url.protocol].request(
-      {
-        protocol: url.protocol,
-        hostname: url.hostname,
-        port: url.port,
-        path: url.pathname + url.search,
-        method,
-        ...config,
-      },
-      (res) => {
-        res.data = "";
+    let req = defaults.req();
+    try {
+      req = protocols[url.protocol].request(
+        {
+          protocol: url.protocol,
+          hostname: url.hostname,
+          port: url.port,
+          path: url.pathname + url.search,
+          method,
+          ...config,
+        },
+        (res) => {
+          res.data = "";
 
-        const chunks = [];
-        res.on("data", (chunk) => {
-          chunks.push(chunk);
-        });
+          const chunks = [];
+          res.on("data", (chunk) => {
+            chunks.push(chunk);
+          });
 
-        res.on("end", () => {
-          // Combines chunks
-          res.data = Buffer.concat(chunks).toString();
+          res.on("end", () => {
+            // Combines chunks
+            res.data = Buffer.concat(chunks).toString();
 
-          this.emit("data", res.data);
+            this.emit("data", res.data);
 
-          // Converts response data based off headers
-          //      Parse json object or construct URLSearchParams
-          res.data = decodeData(res.data, res.getHeader("content-type"));
+            // Converts response data based off headers
+            //      Parse json object or construct URLSearchParams
+            res.data = decodeData(res.data, res.getHeader("content-type"));
 
-          // Handle redirect
-          if (
-            config?.maxRedirects > 0 &&
-            res.statusCode === 301 &&
-            res.getHeader("location")
-          ) {
-            this.emit("redirect", res, config);
-            const { maxRedirects, ...other } = config;
-            return this.#request(
-              res.getHeader("location"),
-              method,
-              { ...other, maxRedirects: maxRedirects - 1 },
-              handlers,
-            );
-          }
+            // Handle redirect
+            if (
+              config?.maxRedirects > 0 &&
+              res.statusCode === 301 &&
+              res.getHeader("location")
+            ) {
+              this.emit("redirect", res, config);
+              const { maxRedirects, ...other } = config;
+              return this.#request(
+                res.getHeader("location"),
+                method,
+                { ...other, maxRedirects: maxRedirects - 1 },
+                handlers,
+              );
+            }
 
-          handlers.onResolve(res);
-        });
-      },
-    );
+            handlers.onResolve(res);
+          });
+        },
+      );
+    } catch (err) {
+      handlers.onReject(req, defaults.res(), err);
+    }
 
     const error = (err) => {
       handlers.onReject(req, defaults.res(), err);

--- a/tests/Nexis.test.js
+++ b/tests/Nexis.test.js
@@ -43,44 +43,59 @@ describe("Nexis instance", () => {
     });
   });
 
-  it("should validate request header", () => {
-    const invalidTokenErr = (err) =>
-      err instanceof TypeError && err.code === "ERR_INVALID_HTTP_TOKEN";
-    const invalidValueErr = (err) =>
-      err instanceof TypeError && err.code === "ERR_HTTP_INVALID_HEADER_VALUE";
-
+  it("should validate request header", async () => {
     // Validate name during set
     assert.throws(
       () =>
         client.setConfig({ headers: { "content type": "application/json" } }),
-      invalidTokenErr,
+      (err) =>
+        err instanceof TypeError && err.code === "ERR_INVALID_HTTP_TOKEN",
       "should reject invalid header name on set",
     );
 
     // Validate value during set
     assert.throws(
       () => client.setConfig({ headers: { "content-type": undefined } }),
-      invalidValueErr,
+      (err) =>
+        err instanceof TypeError &&
+        err.code === "ERR_HTTP_INVALID_HEADER_VALUE",
       "should reject invalid header value on set",
     );
 
-    // Validate name during request
-    assert.rejects(
-      async () =>
-        await client.get("/", {
-          headers: { "content type": "application/json" },
-        }),
-      invalidTokenErr,
-      "should reject invalid header name on request",
-    );
+    // Validate header during request
+    // Receives errors
+    const [nameErr, valueErr] = await Promise.all([
+      new Promise((resolve) =>
+        client
+          .get("/", { headers: { "content type": "application/json" } })
+          .catch(resolve),
+      ),
+      new Promise((resolve) =>
+        client
+          .get("/", { headers: { "content-type": undefined } })
+          .catch(resolve),
+      ),
+    ]);
 
-    // Validate value during request
-    assert.rejects(
-      async () =>
-        await client.get("/", { headers: { "content-type": undefined } }),
-      invalidValueErr,
-      "should reject invalid header value on request",
+    // Invalid name error
+    assert.ok(nameErr.req, "should provide request object");
+    assert.ok(nameErr.res, "should provide response object");
+    assert.strictEqual(
+      nameErr instanceof TypeError,
+      true,
+      "should reject TypeError",
     );
+    assert.strictEqual(nameErr.code, "ERR_INVALID_HTTP_TOKEN");
+
+    // Invalid value error
+    assert.ok(valueErr.req, "should provide request object");
+    assert.ok(valueErr.res, "should provide response object");
+    assert.strictEqual(
+      valueErr instanceof TypeError,
+      true,
+      "should reject TypeError",
+    );
+    assert.strictEqual(valueErr.code, "ERR_HTTP_INVALID_HEADER_VALUE");
   });
 
   it("should have request methods", () => {

--- a/tests/authFormatter.test.js
+++ b/tests/authFormatter.test.js
@@ -35,24 +35,24 @@ describe("Auth Formatter", () => {
 
   it("should reject invalid auth scheme", { timeout: 500 }, (t, done) => {
     const auth = { scheme: "invalid" };
-    new Promise((resolve, reject) =>
-      authFormatter(auth, reject),
-    ).catch((error) => {
-      try {
-        assert.strictEqual(
-          error instanceof TypeError,
-          true,
-          "should reject TypeError",
-        );
-        assert.strictEqual(
-          error.message.includes("Invalid Auth Scheme"),
-          true,
-          "error should include 'Invalid Auth Scheme'",
-        );
-        done();
-      } catch (err) {
-        done(err);
-      }
-    });
+    new Promise((resolve, reject) => authFormatter(auth, reject)).catch(
+      (error) => {
+        try {
+          assert.strictEqual(
+            error instanceof TypeError,
+            true,
+            "should reject TypeError",
+          );
+          assert.strictEqual(
+            error.message.includes("Invalid Auth Scheme"),
+            true,
+            "error should include 'Invalid Auth Scheme'",
+          );
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+    );
   });
 });


### PR DESCRIPTION
This pull request is to merge the branch `41-fix-handle-header-validation-error-on-request` into the `main` branch.

Wrapped the `http(s).request` method in a `try/catch` block to catch the thrown invalid header `error` to be properly handled by the `onReject` handler.