### PR TITLE
52-feat-create-nexis-error-class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,12 +16,30 @@ export type NexisBody =
   | URLSearchParams;
 
 /**
+ * The code of a `NexisError`.
+ */
+export type NexisErrorCode =
+  | "ERR_INVALID_AUTH_SCHEME"
+  | "ERR_INVALID_HTTP_TOKEN"
+  | "ERR_HTTP_INVALID_HEADER_VALUE"
+  | "ERR_HTTP_REQUEST_TIMEOUT";
+
+/**
  * A `Nexis` error with `request` and `response` objects attached.
  */
-export type NexisError = Error & {
+export class NexisError extends Error {
+  constructor(
+    message: string | Error,
+    options?: ErrorOptions & {
+      code?: NexisErrorCode;
+      req?: http.ClientRequest;
+      res?: http.IncomingMessage;
+    },
+  );
+  code: string;
   req: http.ClientRequest;
   res: http.IncomingMessage;
-};
+}
 
 /**
  * A `Nexis` callback function to handle response and error.
@@ -289,6 +307,7 @@ export interface NexisFactory extends Nexis {
  */
 const nexis: NexisFactory & {
   Nexis: Nexis;
+  NexisError: NexisError;
   defaults: defaults;
   protocols: Protocols;
   deepMerge: deepMerge;

--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -1,6 +1,7 @@
 const { Readable } = require("node:stream");
 const { pipeline } = require("node:stream/promises");
 const EventEmitter = require("node:events");
+const NexisError = require("./NexisError");
 const protocols = require("../protocols");
 const defaults = require("../defaults");
 const deepMerge = require("../utils/deepMerge");
@@ -87,19 +88,15 @@ class Nexis extends EventEmitter {
       resolve(res);
     };
 
-    const handleReject = (req, res, err) => {
-      if (req instanceof http.ClientRequest) req.destroy(err);
-      if (res instanceof http.IncomingMessage) res.destroy(err);
-
-      // Attach request and response objects to error
-      err.req = req;
-      err.res = res;
+    const handleReject = (err) => {
+      if (err?.req instanceof http.ClientRequest) err.req.destroy(err);
+      if (err?.res instanceof http.IncomingMessage) err.res.destroy(err);
 
       // Determines error handler
       if (this.listenerCount("error") > 0) {
         this.emit("error", err);
       } else if (cb) {
-        cb(res, err);
+        cb(err?.res, err);
       } else {
         reject(err);
       }
@@ -115,9 +112,10 @@ class Nexis extends EventEmitter {
     config = deepMerge({ headers: { date: new Date().toUTCString() } }, config);
 
     // Formats authorization if in json form
-    const newAuth = authFormatter(config?.headers?.authorization, (err) => {
-      handlers.onReject(defaults.req(), defaults.res(), err);
-    });
+    const newAuth = authFormatter(
+      config?.headers?.authorization,
+      handlers.onReject,
+    );
     if (newAuth) config.headers.authorization = newAuth;
 
     const url = new URL(path, this.#baseURL);
@@ -171,7 +169,7 @@ class Nexis extends EventEmitter {
         },
       );
     } catch (err) {
-      handlers.onReject(req, defaults.res(), err);
+      handlers.onReject(new NexisError(err));
     }
 
     const error = (err) => {
@@ -187,13 +185,12 @@ class Nexis extends EventEmitter {
       req.on("error", () => null);
 
       handlers.onReject(
-        req,
-        defaults.res(),
-        new Error(
+        new NexisError(
           `Socket Connection Timeout: ${config.timeout}ms Path: ${req.path}`,
           {
             cause: "The server didn't respond before the timeout",
             code: "ERR_HTTP_REQUEST_TIMEOUT",
+            req,
           },
         ),
       );

--- a/lib/core/NexisError.js
+++ b/lib/core/NexisError.js
@@ -1,0 +1,21 @@
+const defaults = require("../defaults");
+
+class NexisError extends Error {
+  constructor(message, options = {}) {
+    const { req = defaults.req(), res = defaults.res(), ...other } = options;
+
+    if (message instanceof Error) {
+      const { message: mess, stack } = message;
+      super(mess, { stack, ...other });
+    } else {
+      super(message, other);
+    }
+
+    this.code = other.code || message.code || null;
+
+    this.req = req;
+    this.res = res;
+  }
+}
+
+exports = module.exports = NexisError;

--- a/lib/nexis.js
+++ b/lib/nexis.js
@@ -1,5 +1,6 @@
 const createClient = require("./core/createClient");
 const Nexis = require("./core/Nexis");
+const NexisError = require("./core/NexisError");
 const defaults = require("./defaults");
 const protocols = require("./protocols");
 const deepMerge = require("./utils/deepMerge");
@@ -10,6 +11,7 @@ const authFormatter = require("./utils/authFormatter");
 const nexis = createClient({ baseURL: defaults.baseURL, ...defaults.config() });
 
 nexis.Nexis = Nexis;
+nexis.NexisError = NexisError;
 
 nexis.defaults = defaults;
 nexis.protocols = protocols;

--- a/lib/utils/authFormatter.js
+++ b/lib/utils/authFormatter.js
@@ -1,3 +1,5 @@
+const NexisError = require("../core/NexisError");
+
 exports = module.exports = authFormatter;
 
 function authFormatter(auth, onReject) {
@@ -26,6 +28,10 @@ function authFormatter(auth, onReject) {
       return string.slice(0, string.length - 1);
 
     default:
-      onReject(new TypeError("Invalid Auth Scheme"));
+      onReject(
+        new NexisError("Invalid Auth Scheme", {
+          code: "ERR_INVALID_AUTH_SCHEME",
+        }),
+      );
   }
 }

--- a/tests/Nexis.test.js
+++ b/tests/Nexis.test.js
@@ -4,6 +4,7 @@ const http = require("node:http");
 const Nexis = require("../lib/core/Nexis");
 const defaults = require("../lib/defaults");
 const protocols = require("../lib/protocols");
+const NexisError = require("../lib/core/NexisError");
 
 describe("Nexis class", () => {
   it("should be a class", () => {
@@ -81,9 +82,9 @@ describe("Nexis instance", () => {
     assert.ok(nameErr.req, "should provide request object");
     assert.ok(nameErr.res, "should provide response object");
     assert.strictEqual(
-      nameErr instanceof TypeError,
+      nameErr instanceof NexisError,
       true,
-      "should reject TypeError",
+      "should reject NexisError",
     );
     assert.strictEqual(nameErr.code, "ERR_INVALID_HTTP_TOKEN");
 
@@ -91,9 +92,9 @@ describe("Nexis instance", () => {
     assert.ok(valueErr.req, "should provide request object");
     assert.ok(valueErr.res, "should provide response object");
     assert.strictEqual(
-      valueErr instanceof TypeError,
+      valueErr instanceof NexisError,
       true,
-      "should reject TypeError",
+      "should reject NexisError",
     );
     assert.strictEqual(valueErr.code, "ERR_HTTP_INVALID_HEADER_VALUE");
   });

--- a/tests/NexisError.test.js
+++ b/tests/NexisError.test.js
@@ -1,0 +1,30 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const NexisError = require("../lib/core/NexisError");
+
+describe("NexisError class", () => {
+  it("should be a class", () => {
+    assert.strictEqual(typeof NexisError, "function");
+    assert.match(NexisError.toString(), /^class\s/);
+  });
+});
+
+describe("NexisError instance", () => {
+  const err = new NexisError("message", {
+    code: "ERR",
+    cause: "cause",
+  });
+
+  it("should be extended from Error", () => {
+    assert.strictEqual(err instanceof Error, true, "should extend from Error");
+    assert.ok(err.message, "should have message");
+    assert.ok(err.code, "should have code");
+    assert.ok(err.cause, "should have cause");
+    assert.ok(err.stack, "should have stack");
+  });
+
+  it("should have request & response objects", () => {
+    assert.ok(err.req, "should have request object");
+    assert.ok(err.res, "should have response object");
+  });
+});

--- a/tests/authFormatter.test.js
+++ b/tests/authFormatter.test.js
@@ -1,6 +1,7 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
 const authFormatter = require("../lib/utils/authFormatter");
+const NexisError = require("../lib/core/NexisError");
 
 describe("Auth Formatter", () => {
   it("should be a function", () => {
@@ -39,9 +40,9 @@ describe("Auth Formatter", () => {
       (error) => {
         try {
           assert.strictEqual(
-            error instanceof TypeError,
+            error instanceof NexisError,
             true,
-            "should reject TypeError",
+            "should reject NexisError",
           );
           assert.strictEqual(
             error.message.includes("Invalid Auth Scheme"),

--- a/tests/cjs-export.test.js
+++ b/tests/cjs-export.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert");
 const nexis = require("../index");
 const {
   Nexis,
+  NexisError,
   defaults,
   protocols,
   deepMerge,
@@ -19,6 +20,11 @@ describe("cjs exports", () => {
   it("Nexis class", () => {
     assert.strictEqual(typeof Nexis, "function");
     assert.match(Nexis.toString(), /^class\s/);
+  });
+
+  it("NexisError class", () => {
+    assert.strictEqual(typeof NexisError, "function");
+    assert.match(NexisError.toString(), /^class\s/);
   });
 
   it("default values", () => {

--- a/tests/esm-export.test.mjs
+++ b/tests/esm-export.test.mjs
@@ -12,6 +12,11 @@ describe("esm exports", () => {
     assert.match(nexis.Nexis.toString(), /^class\s/);
   });
 
+  it("NexisError class", () => {
+    assert.strictEqual(typeof nexis.NexisError, "function");
+    assert.match(nexis.NexisError.toString(), /^class\s/);
+  });
+
   it("default values", () => {
     assert.strictEqual(typeof nexis.defaults, "object");
   });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -313,9 +313,9 @@ describe("requests on test server", () => {
         assert.ok(error.req, "should provide request object");
         assert.ok(error.res, "should provide response object");
         assert.strictEqual(
-          error instanceof TypeError,
+          error instanceof nexis.NexisError,
           true,
-          "should reject TypeError",
+          "should reject NexisError",
         );
         assert.strictEqual(
           error.message.includes("Invalid Auth Scheme"),


### PR DESCRIPTION
This pull request is to merge the branch `52-feat-create-nexis-error-class` into the `main` branch.

Implemented `NexisError` class that extends from `Error` and attaches the `request` & `response` objects. Rather then it being done in the `handleReject` function.