### PR TITLE
46-fix-implement-input-validation-and-defaults

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -50,6 +50,15 @@ export type NexisCallback = (
 ) => void;
 
 /**
+ * A `Nexis` method request function.
+ */
+export type NexisMethodRequest = (
+  path?: string | URL,
+  configOrCb?: http.RequestOptions | NexisCallback,
+  cb?: NexisCallback,
+) => Promise<http.IncomingMessage>;
+
+/**
  * Configuration options for a `Nexis` instance.
  */
 export type NexisConfig = http.RequestOptions & {
@@ -76,6 +85,8 @@ export class NexisIncomingMessage extends http.IncomingMessage {
  */
 export type defaults = {
   baseURL: "http://localhost:80/";
+  path: "/";
+  method: { read: "get"; write: "post" };
   config: () => {
     port: 80;
     timeout: 10000;
@@ -205,7 +216,7 @@ export class Nexis extends EventEmitter<NexisEvents> {
    * @class
    * @extends {EventEmitter}
    */
-  constructor(config: NexisConfig);
+  constructor(config?: NexisConfig);
 
   getBaseURL(): URL;
   getConfig(): http.RequestOptions;
@@ -216,8 +227,8 @@ export class Nexis extends EventEmitter<NexisEvents> {
    * Makes a read request which is either a `get` or `delete` method.
    */
   read(
-    path: string | URL,
-    method: "get" | "delete",
+    path?: string | URL,
+    method?: "get" | "delete",
     configOrCb?: http.RequestOptions | NexisCallback,
     cb?: NexisCallback,
   ): Promise<http.IncomingMessage>;
@@ -226,8 +237,8 @@ export class Nexis extends EventEmitter<NexisEvents> {
    * Makes a write request which is either a `post`, `put` or `patch` method.
    */
   write(
-    path: string | URL,
-    method: "post" | "put" | "patch",
+    path?: string | URL,
+    method?: "post" | "put" | "patch",
     configOrCb?: http.RequestOptions | NexisCallback,
     cb?: NexisCallback,
   ): Promise<http.IncomingMessage>;
@@ -235,50 +246,27 @@ export class Nexis extends EventEmitter<NexisEvents> {
   /**
    * Make a http(s) get request.
    */
-  get(
-    path: string | URL,
-    configOrCb?: http.RequestOptions | NexisCallback,
-    cb?: NexisCallback,
-  ): Promise<http.IncomingMessage>;
+  get: NexisMethodRequest;
 
   /**
    * Make a http(s) delete request.
    */
-  delete(
-    path: string | URL,
-    configOrCb?: http.RequestOptions | NexisCallback,
-    cb?: NexisCallback,
-  ): Promise<http.IncomingMessage>;
+  delete: NexisMethodRequest;
 
   /**
    * Make a http(s) post request.
    */
-  post(
-    path: string | URL,
-    body: NexisBody,
-    configOrCb?: http.RequestOptions | NexisCallback,
-    cb?: NexisCallback,
-  ): Promise<http.IncomingMessage>;
+  post: NexisMethodRequest;
 
   /**
    * Make a http(s) put request.
    */
-  put(
-    path: string | URL,
-    body: NexisBody,
-    configOrCb?: http.RequestOptions | NexisCallback,
-    cb?: NexisCallback,
-  ): Promise<http.IncomingMessage>;
+  put: NexisMethodRequest;
 
   /**
    * Make a http(s) patch request.
    */
-  patch(
-    path: string | URL,
-    body: NexisBody,
-    configOrCb?: http.RequestOptions | NexisCallback,
-    cb?: NexisCallback,
-  ): Promise<http.IncomingMessage>;
+  patch: NexisMethodRequest;
 
   Agent: http.Agent;
   ClientRequest: http.ClientRequest;
@@ -300,7 +288,7 @@ export interface NexisFactory extends Nexis {
   /**
    * Creates another `NexisFactory` instance, `instanceConfig` is merged with the `defaultConfig` of this instance.
    */
-  create(instanceConfig: NexisConfig): NexisFactory;
+  create(instanceConfig?: NexisConfig): NexisFactory;
 }
 /**
  * A `NexisFactory` instance with default configuration.

--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -14,13 +14,13 @@ class Nexis extends EventEmitter {
   #baseURL = defaults.baseURL;
   #config = defaults.config();
 
-  constructor(config) {
+  constructor(config = {}) {
     super();
 
-    const { baseURL, ...otherConfig } = config;
+    const { baseURL = defaults.baseURL, ...otherConfig } = config;
 
     this.setBaseURL(baseURL);
-    this.setConfig(otherConfig);
+    this.setConfig(otherConfig || defaults.config());
 
     // Inherit exclusive http properties
     [
@@ -200,7 +200,7 @@ class Nexis extends EventEmitter {
     handlers.onRequest(req);
   }
 
-  read(path, method, configOrCb, cb) {
+  read(path = defaults.path, method = defaults.method["read"], configOrCb, cb) {
     return new Promise((resolve, reject) => {
       // Resolve callback & merge configs
       const [config, callback] = this.#handleCallbackConfig(configOrCb, cb);
@@ -214,7 +214,13 @@ class Nexis extends EventEmitter {
     });
   }
 
-  write(path, method, body, configOrCb, cb) {
+  write(
+    path = defaults.path,
+    method = defaults.method["write"],
+    body,
+    configOrCb,
+    cb,
+  ) {
     return new Promise((resolve, reject) => {
       // Resolve callback & merge configs
       let [config, callback] = this.#handleCallbackConfig(configOrCb, cb);
@@ -225,6 +231,8 @@ class Nexis extends EventEmitter {
 
       const handlers = this.#generateHandlers(resolve, reject, callback);
       handlers.onRequest = function handleRequest(req) {
+        if (!data) return req.end();
+
         // Feeds data to req writable stream
         pipeline(Readable.from(data), req).catch((err) => {
           this.onReject(req, defaults.res(), err);

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,5 +1,7 @@
 const defaults = {
   baseURL: "http://localhost:80/",
+  path: "/",
+  method: { read: "get", write: "post" },
   config: () => ({
     port: 80,
     timeout: 10000,

--- a/lib/utils/decodeData.js
+++ b/lib/utils/decodeData.js
@@ -1,6 +1,8 @@
 exports = module.exports = decodeData;
 
 function decodeData(data, contentType) {
+  if (!data || !contentType) return data;
+
   // Decode response data based off content type
   if (contentType === "application/json") return JSON.parse(data);
 

--- a/tests/Nexis.test.js
+++ b/tests/Nexis.test.js
@@ -11,6 +11,10 @@ describe("Nexis class", () => {
     assert.strictEqual(typeof Nexis, "function");
     assert.match(Nexis.toString(), /^class\s/);
   });
+
+  it("should construct without optional params", () => {
+    assert.strictEqual(new Nexis() instanceof Nexis, true);
+  });
 });
 
 describe("Nexis instance", () => {

--- a/tests/createClient.test.js
+++ b/tests/createClient.test.js
@@ -17,6 +17,10 @@ describe("client creator", () => {
     assert.strictEqual(client instanceof Nexis, true);
   });
 
+  it("should return client without optional params", () => {
+    assert.strictEqual(createClient() instanceof Nexis, true);
+  });
+
   it("should return client with extended creation", () => {
     assert.strictEqual(typeof client.create, "function");
 

--- a/tests/defaults.test.js
+++ b/tests/defaults.test.js
@@ -5,9 +5,13 @@ const defaults = require("../lib/defaults");
 describe("default values", () => {
   it("should have defined default values", () => {
     assert.strictEqual(typeof defaults.baseURL, "string");
+    assert.strictEqual(typeof defaults.path, "string");
+    assert.strictEqual(typeof defaults.method, "object");
     assert.strictEqual(typeof defaults.config, "function");
     assert.strictEqual(typeof defaults.config(), "object");
     assert.strictEqual(typeof defaults.res, "function");
     assert.strictEqual(typeof defaults.res(), "object");
+    assert.strictEqual(typeof defaults.req, "function");
+    assert.strictEqual(typeof defaults.req(), "object");
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -183,11 +183,22 @@ describe("requests on test server", () => {
     assert.strictEqual(response.data, "Hello, World!");
   });
 
+  it("read get request default params", async () => {
+    const response = await client.read();
+    assert.strictEqual(response.statusCode, 200);
+    assert.strictEqual(response.data, "Hello, World!");
+  });
+
   it("write post request", async () => {
     const data = { message: "Hello, World!" };
     const response = await client.write("/", "post", data);
     assert.strictEqual(response.statusCode, 200);
     assert.deepStrictEqual(response.data, data);
+  });
+
+  it("write post request default params", async () => {
+    const response = await client.write();
+    assert.strictEqual(response.statusCode, 200);
   });
 
   it("basic get request promise response", async () => {
@@ -201,6 +212,17 @@ describe("requests on test server", () => {
       assert.strictEqual(response.statusCode, 200);
       assert.strictEqual(response.data, "Hello, World!");
     });
+  });
+
+  it("basic get request default params", async () => {
+    const response = await client.get();
+    assert.strictEqual(response.statusCode, 200);
+    assert.strictEqual(response.data, "Hello, World!");
+  });
+
+  it("basic post request default params", async () => {
+    const response = await client.post();
+    assert.strictEqual(response.statusCode, 200);
   });
 
   it("post object request", async () => {


### PR DESCRIPTION
This pull request is to merge the branch `46-fix-implement-input-validation-and-defaults` into the `main` branch.

Implemented param default values for every `Nexis` method and the `create` method. Added `path` & `method` default values to the `defaults` object.