### PR TITLE
59-fix-errors-handled-by-event-listener-doesnt-resolve-promise

### DIFF
--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -92,10 +92,10 @@ class Nexis extends EventEmitter {
       if (err?.req instanceof http.ClientRequest) err.req.destroy(err);
       if (err?.res instanceof http.IncomingMessage) err.res.destroy(err);
 
-      // Determines error handler
-      if (this.listenerCount("error") > 0) {
-        this.emit("error", err);
-      } else if (cb) {
+      // Handles error by first calling event listeners if there are
+      //    Then finishing handling through callback or rejection
+      if (this.listenerCount("error") > 0) this.emit("error", err);
+      if (cb) {
         cb(err?.res, err);
       } else {
         reject(err);

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -500,6 +500,11 @@ describe("requests on test server", () => {
     });
 
     // Creates timeout error
-    client.get("/timeout", { timeout: 1 });
+    client.get("/timeout", { timeout: 1 }).catch(() => null);
+  });
+
+  it("get events error request async", { timeout }, async () => {
+    client.once("error", (error) => error);
+    await client.get("/timeout", { timeout: 1 }).catch(() => null);
   });
 });


### PR DESCRIPTION
This pull request is to merge the branch `59-fix-errors-handled-by-event-listener-doesnt-resolve-promise` into the `main` branch.

Changed `error` handling by instead of the event listener fully handling the `error`, the `error` is still other handled by the `callback` function or is `rejected`. This solves an issue where the code would freeze when `awaiting` for a promise that isn't `resolved` or `rejected` because a event listener would handle the `error`. 