### PR TITLE
44 feat implement automatic event logger handlers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -87,6 +87,7 @@ export type defaults = {
   baseURL: "http://localhost:80/";
   path: "/";
   method: { read: "get"; write: "post" };
+  unknown: "[Unknown]";
   config: () => {
     port: 80;
     timeout: 10000;

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,6 +64,7 @@ export type NexisMethodRequest = (
 export type NexisConfig = http.RequestOptions & {
   baseURL: string | URL;
   maxRedirects?: number;
+  loggers: { request: boolean; response: boolean; error: boolean };
 };
 
 /**

--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -9,6 +9,7 @@ const encodeConfigBody = require("../utils/encodeConfigBody");
 const decodeData = require("../utils/decodeData");
 const authFormatter = require("../utils/authFormatter");
 const http = require("../utils/header-methods");
+const loggers = require("../utils/event-loggers");
 
 class Nexis extends EventEmitter {
   #baseURL = defaults.baseURL;
@@ -117,6 +118,13 @@ class Nexis extends EventEmitter {
       handlers.onReject,
     );
     if (newAuth) config.headers.authorization = newAuth;
+
+    // Add event loggers
+    if (config?.loggers) {
+      Object.entries(config.loggers).forEach(([event, bool]) => {
+        if (bool && loggers[event]) this.once(event, loggers[event]);
+      });
+    }
 
     const url = new URL(path, this.#baseURL);
     let req = defaults.req();

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -2,6 +2,7 @@ const defaults = {
   baseURL: "http://localhost:80/",
   path: "/",
   method: { read: "get", write: "post" },
+  unknown: "[Unknown]",
   config: () => ({
     port: 80,
     timeout: 10000,

--- a/lib/utils/event-loggers.js
+++ b/lib/utils/event-loggers.js
@@ -1,0 +1,18 @@
+exports = module.exports = { error, request, response }
+
+function error(err) {
+    console.error("[Nexis Error]:", err);
+}
+
+function request(req) {
+    const { method, protocol = "", path = "", query = "" } = req;
+    const host = req.getHeader("host") || "";
+    console.info("[Nexis Request]:", { method, url: `${protocol}${host}${path}${query}`, timestamp: new Date() });
+}
+
+function response(res) {
+    const { statusCode, statusMessage, req } = res;
+    const { method = "", protocol = "", path = "", query = "" } = req;
+    const host = res.req.getHeader("host") || "";
+    console.info("[Nexis Response]:", { method, status: `${statusCode} ${statusMessage}`, url: `${protocol}${host}${path}${query}`, timestamp: new Date() });
+}

--- a/lib/utils/event-loggers.js
+++ b/lib/utils/event-loggers.js
@@ -1,18 +1,46 @@
-exports = module.exports = { error, request, response }
+const defaults = require("../defaults");
+
+exports = module.exports = { error, request, response };
+
+function getURL(req) {
+  const { protocol = "", path = "" } = req;
+  const host = req?.getHeader ? req.getHeader("host") : defaults.unknown;
+
+  return protocol + host + path;
+}
+
+function requestInfo(req = defaults.req()) {
+  return {
+    method: req.method ?? defaults.unknown,
+    url: getURL(req),
+    timestamp: new Date(),
+  };
+}
+
+function responseInfo(res = defaults.res()) {
+  const { statusCode, statusMessage } = res;
+  return {
+    status:
+      !statusCode || !statusMessage
+        ? defaults.unknown
+        : `${statusCode} ${statusMessage}`,
+    timestamp: new Date(),
+  };
+}
 
 function error(err) {
-    console.error("[Nexis Error]:", err);
+  err.req = requestInfo(err?.req);
+  err.res = responseInfo(err?.res);
+  console.error("[Nexis Error]:", err);
 }
 
 function request(req) {
-    const { method, protocol = "", path = "", query = "" } = req;
-    const host = req.getHeader("host") || "";
-    console.info("[Nexis Request]:", { method, url: `${protocol}${host}${path}${query}`, timestamp: new Date() });
+  console.info("[Nexis Request]:", requestInfo(req));
 }
 
 function response(res) {
-    const { statusCode, statusMessage, req } = res;
-    const { method = "", protocol = "", path = "", query = "" } = req;
-    const host = res.req.getHeader("host") || "";
-    console.info("[Nexis Response]:", { method, status: `${statusCode} ${statusMessage}`, url: `${protocol}${host}${path}${query}`, timestamp: new Date() });
+  console.info("[Nexis Response]:", {
+    ...responseInfo(res),
+    ...requestInfo(res?.req),
+  });
 }

--- a/tests/defaults.test.js
+++ b/tests/defaults.test.js
@@ -7,6 +7,7 @@ describe("default values", () => {
     assert.strictEqual(typeof defaults.baseURL, "string");
     assert.strictEqual(typeof defaults.path, "string");
     assert.strictEqual(typeof defaults.method, "object");
+    assert.strictEqual(typeof defaults.unknown, "string");
     assert.strictEqual(typeof defaults.config, "function");
     assert.strictEqual(typeof defaults.config(), "object");
     assert.strictEqual(typeof defaults.res, "function");

--- a/tests/event-loggers.test.js
+++ b/tests/event-loggers.test.js
@@ -1,0 +1,89 @@
+const { describe, it, mock } = require("node:test");
+const assert = require("node:assert");
+const { error, request, response } = require("../lib/utils/event-loggers");
+
+describe("error event logger", () => {
+    it("should be a function", () => {
+        assert.strictEqual(typeof error, "function");
+    });
+
+    it("should log a error", () => {
+        const errorMock = mock.method(console, "error", () => null);
+        const err = new Error("Error");
+
+        error(err);
+
+        assert.strictEqual(errorMock.mock.callCount(), 1, "should make console.error call");
+        
+        const call = errorMock.mock.calls[0];
+        assert.strictEqual(call.arguments[0], "[Nexis Error]:", "should label Nexis Error");
+        assert.deepStrictEqual(call.arguments[1], err, "should log Nexis Error");
+
+        errorMock.mock.restore();
+    });
+});
+
+describe("request event logger", () => {
+    it("should be a function", () => {
+        assert.strictEqual(typeof request, "function");
+    });
+
+    it("should log request information", () => {
+        const requestMock = mock.method(console, "info", () => null);
+        const req = {
+            method: "GET",
+            protocol: "http:",
+            getHeader: (name) => name === "host" ? "localhost:3000" : null,
+            path: "/request"
+        }
+
+        request(req);
+
+        assert.strictEqual(requestMock.mock.callCount(), 1, "should make console.info call");
+
+        const call = requestMock.mock.calls[0];
+        assert.strictEqual(call.arguments[0], "[Nexis Request]:", "should label Nexis Request");
+        const loggedInfo = call.arguments[1];
+        assert.strictEqual(loggedInfo.method, req.method, "should log request method");
+        assert.strictEqual(loggedInfo.url, `${req.protocol}${req.getHeader("host")}${req.path}`, "should log request url");
+        assert.ok(loggedInfo.timestamp, "should log request timestamp");
+
+        requestMock.mock.restore();
+    });
+});
+
+describe("response event logger", () => {
+    it("should be a function", () => {
+        assert.strictEqual(typeof response, "function");
+    });
+
+    it("should log response information", () => {
+        const responseMock = mock.method(console, "info", () => null);
+        const res = { 
+            statusCode: 200, 
+            statusMessage: "OK", 
+            req: {
+                method: "GET", 
+                protocol: "http:",
+                getHeader: (name) => name === "host" ? "localhost:3000" : null, 
+                path: "/response"
+            }
+        }
+
+        response(res);
+
+        assert.strictEqual(responseMock.mock.callCount(), 1, "should make console.info call");
+
+        const call = responseMock.mock.calls[0];
+        assert.strictEqual(call.arguments[0], "[Nexis Response]:", "should label Nexis Response");
+        const loggedInfo = call.arguments[1];
+        assert.strictEqual(loggedInfo.status, `${res.statusCode} ${res.statusMessage}`, "should log response status");
+        assert.ok(loggedInfo.timestamp, "should label response timestamp");
+
+        const req = res.req;
+        assert.strictEqual(loggedInfo.method, req.method, "should log response method");
+        assert.strictEqual(loggedInfo.url, `${req.protocol}${req.getHeader("host")}${req.path}`, "should log response url");
+
+        responseMock.mock.restore();
+    });
+});

--- a/tests/event-loggers.test.js
+++ b/tests/event-loggers.test.js
@@ -161,7 +161,6 @@ describe("response event logger", () => {
     );
     assert.ok(loggedInfo.timestamp, "should label response timestamp");
 
-    const req = res.req;
     assert.strictEqual(
       loggedInfo.method,
       defaults.unknown,

--- a/tests/event-loggers.test.js
+++ b/tests/event-loggers.test.js
@@ -1,89 +1,245 @@
 const { describe, it, mock } = require("node:test");
 const assert = require("node:assert");
 const { error, request, response } = require("../lib/utils/event-loggers");
+const defaults = require("../lib/defaults");
 
-describe("error event logger", () => {
-    it("should be a function", () => {
-        assert.strictEqual(typeof error, "function");
-    });
-
-    it("should log a error", () => {
-        const errorMock = mock.method(console, "error", () => null);
-        const err = new Error("Error");
-
-        error(err);
-
-        assert.strictEqual(errorMock.mock.callCount(), 1, "should make console.error call");
-        
-        const call = errorMock.mock.calls[0];
-        assert.strictEqual(call.arguments[0], "[Nexis Error]:", "should label Nexis Error");
-        assert.deepStrictEqual(call.arguments[1], err, "should log Nexis Error");
-
-        errorMock.mock.restore();
-    });
-});
+// Construct Test Data
+const req = {
+  method: "GET",
+  protocol: "http:",
+  getHeader: (name) => (name === "host" ? "localhost:3000" : null),
+  path: "/request",
+};
+const res = {
+  statusCode: 200,
+  statusMessage: "OK",
+  req,
+};
+const err = new Error("Error");
+err.req = req;
+err.res = res;
 
 describe("request event logger", () => {
-    it("should be a function", () => {
-        assert.strictEqual(typeof request, "function");
-    });
+  it("should be a function", () => {
+    assert.strictEqual(typeof request, "function");
+  });
 
-    it("should log request information", () => {
-        const requestMock = mock.method(console, "info", () => null);
-        const req = {
-            method: "GET",
-            protocol: "http:",
-            getHeader: (name) => name === "host" ? "localhost:3000" : null,
-            path: "/request"
-        }
+  it("should log request info", () => {
+    const requestMock = mock.method(console, "info", () => null);
 
-        request(req);
+    request(req);
 
-        assert.strictEqual(requestMock.mock.callCount(), 1, "should make console.info call");
+    assert.strictEqual(
+      requestMock.mock.callCount(),
+      1,
+      "should make console.info call",
+    );
 
-        const call = requestMock.mock.calls[0];
-        assert.strictEqual(call.arguments[0], "[Nexis Request]:", "should label Nexis Request");
-        const loggedInfo = call.arguments[1];
-        assert.strictEqual(loggedInfo.method, req.method, "should log request method");
-        assert.strictEqual(loggedInfo.url, `${req.protocol}${req.getHeader("host")}${req.path}`, "should log request url");
-        assert.ok(loggedInfo.timestamp, "should log request timestamp");
+    const call = requestMock.mock.calls[0];
+    assert.strictEqual(
+      call.arguments[0],
+      "[Nexis Request]:",
+      "should label Nexis Request",
+    );
+    const loggedInfo = call.arguments[1];
+    assert.strictEqual(
+      loggedInfo.method,
+      req.method,
+      "should log request method",
+    );
+    assert.strictEqual(
+      loggedInfo.url,
+      `${req.protocol}${req.getHeader("host")}${req.path}`,
+      "should log request url",
+    );
+    assert.ok(loggedInfo.timestamp, "should log request timestamp");
 
-        requestMock.mock.restore();
-    });
+    requestMock.mock.restore();
+  });
+
+  it("should log request unknown info", () => {
+    const requestMock = mock.method(console, "info", () => null);
+
+    request();
+
+    assert.strictEqual(
+      requestMock.mock.callCount(),
+      1,
+      "should make console.info call",
+    );
+
+    const call = requestMock.mock.calls[0];
+    assert.strictEqual(
+      call.arguments[0],
+      "[Nexis Request]:",
+      "should label Nexis Request",
+    );
+    const loggedInfo = call.arguments[1];
+    assert.strictEqual(
+      loggedInfo.method,
+      defaults.unknown,
+      "should log unknown method",
+    );
+    assert.strictEqual(
+      loggedInfo.url,
+      defaults.unknown,
+      "should log unknwon url",
+    );
+    assert.ok(loggedInfo.timestamp, "should log request timestamp");
+
+    requestMock.mock.restore();
+  });
 });
 
 describe("response event logger", () => {
-    it("should be a function", () => {
-        assert.strictEqual(typeof response, "function");
-    });
+  it("should be a function", () => {
+    assert.strictEqual(typeof response, "function");
+  });
 
-    it("should log response information", () => {
-        const responseMock = mock.method(console, "info", () => null);
-        const res = { 
-            statusCode: 200, 
-            statusMessage: "OK", 
-            req: {
-                method: "GET", 
-                protocol: "http:",
-                getHeader: (name) => name === "host" ? "localhost:3000" : null, 
-                path: "/response"
-            }
-        }
+  it("should log response info", () => {
+    const responseMock = mock.method(console, "info", () => null);
 
-        response(res);
+    response(res);
 
-        assert.strictEqual(responseMock.mock.callCount(), 1, "should make console.info call");
+    assert.strictEqual(
+      responseMock.mock.callCount(),
+      1,
+      "should make console.info call",
+    );
 
-        const call = responseMock.mock.calls[0];
-        assert.strictEqual(call.arguments[0], "[Nexis Response]:", "should label Nexis Response");
-        const loggedInfo = call.arguments[1];
-        assert.strictEqual(loggedInfo.status, `${res.statusCode} ${res.statusMessage}`, "should log response status");
-        assert.ok(loggedInfo.timestamp, "should label response timestamp");
+    const call = responseMock.mock.calls[0];
+    assert.strictEqual(
+      call.arguments[0],
+      "[Nexis Response]:",
+      "should label Nexis Response",
+    );
+    const loggedInfo = call.arguments[1];
+    assert.strictEqual(
+      loggedInfo.status,
+      `${res.statusCode} ${res.statusMessage}`,
+      "should log response status",
+    );
+    assert.ok(loggedInfo.timestamp, "should label response timestamp");
 
-        const req = res.req;
-        assert.strictEqual(loggedInfo.method, req.method, "should log response method");
-        assert.strictEqual(loggedInfo.url, `${req.protocol}${req.getHeader("host")}${req.path}`, "should log response url");
+    const req = res.req;
+    assert.strictEqual(
+      loggedInfo.method,
+      req.method,
+      "should log response method",
+    );
+    assert.strictEqual(
+      loggedInfo.url,
+      `${req.protocol}${req.getHeader("host")}${req.path}`,
+      "should log response url",
+    );
 
-        responseMock.mock.restore();
-    });
+    responseMock.mock.restore();
+  });
+
+  it("should log response unknwon info", () => {
+    const responseMock = mock.method(console, "info", () => null);
+
+    response();
+
+    assert.strictEqual(
+      responseMock.mock.callCount(),
+      1,
+      "should make console.info call",
+    );
+
+    const call = responseMock.mock.calls[0];
+    assert.strictEqual(
+      call.arguments[0],
+      "[Nexis Response]:",
+      "should label Nexis Response",
+    );
+    const loggedInfo = call.arguments[1];
+    assert.strictEqual(
+      loggedInfo.status,
+      defaults.unknown,
+      "should log unknown status",
+    );
+    assert.ok(loggedInfo.timestamp, "should label response timestamp");
+
+    const req = res.req;
+    assert.strictEqual(
+      loggedInfo.method,
+      defaults.unknown,
+      "should log unknwon method",
+    );
+    assert.strictEqual(
+      loggedInfo.url,
+      defaults.unknown,
+      "should log unknown url",
+    );
+
+    responseMock.mock.restore();
+  });
+});
+
+describe("error event logger", () => {
+  it("should be a function", () => {
+    assert.strictEqual(typeof error, "function");
+  });
+
+  it("should log a error", () => {
+    const errorMock = mock.method(console, "error", () => null);
+
+    error(err);
+
+    assert.strictEqual(
+      errorMock.mock.callCount(),
+      1,
+      "should make console.error call",
+    );
+
+    const call = errorMock.mock.calls[0];
+    assert.strictEqual(
+      call.arguments[0],
+      "[Nexis Error]:",
+      "should label Nexis Error",
+    );
+    assert.deepStrictEqual(call.arguments[1], err, "should log Nexis Error");
+
+    errorMock.mock.restore();
+  });
+
+  it("should log unknown request & response info", () => {
+    const errorMock = mock.method(console, "error", () => null);
+
+    err.req = undefined;
+    err.res = undefined;
+    error(err);
+
+    assert.strictEqual(
+      errorMock.mock.callCount(),
+      1,
+      "should make console.error call",
+    );
+
+    const call = errorMock.mock.calls[0];
+    assert.strictEqual(
+      call.arguments[0],
+      "[Nexis Error]:",
+      "should label Nexis Error",
+    );
+    const loggedReq = call.arguments[1].req;
+    assert.strictEqual(
+      loggedReq.method,
+      defaults.unknown,
+      "should log unknown request method",
+    );
+    assert.strictEqual(
+      loggedReq.url,
+      defaults.unknown,
+      "should log unknwon request url",
+    );
+    assert.strictEqual(
+      call.arguments[1].res.status,
+      defaults.unknown,
+      "should log unknown response status",
+    );
+
+    errorMock.mock.restore();
+  });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after } = require("node:test");
+const { describe, it, mock, before, after } = require("node:test");
 const assert = require("node:assert");
 const http = require("node:http");
 const Stream = require("node:stream");
@@ -506,5 +506,43 @@ describe("requests on test server", () => {
   it("get events error request async", { timeout }, async () => {
     client.once("error", (error) => error);
     await client.get("/timeout", { timeout: 1 }).catch(() => null);
+  });
+
+  it("request & response event loggers", async () => {
+    const infoMock = mock.method(console, "info", () => null);
+    
+    await client.get("/", { loggers: { request: true, response: true }});
+    
+    assert.strictEqual(infoMock.mock.callCount(), 2, "should make two console.info calls");
+    const [requestCall, responseCall] = infoMock.mock.calls;
+
+    assert.strictEqual(requestCall.arguments[0], "[Nexis Request]:", "should label Nexis Request");
+    const request = requestCall.arguments[1];
+    assert.strictEqual(request.method, "GET", "should log request method");
+    assert.strictEqual(request.url, "http:localhost:3000/", "should log request url");
+    assert.ok(request.timestamp, "should log request timestamp");
+
+    assert.strictEqual(responseCall.arguments[0], "[Nexis Response]:", "should label Nexis Response");
+    const response = responseCall.arguments[1];
+    assert.strictEqual(response.method, "GET", "should log response method");
+    assert.strictEqual(response.status, "200 OK", "should log response status");
+    assert.strictEqual(response.url, "http:localhost:3000/", "should log response url");
+    assert.ok(response.timestamp, "should log response timestamp");
+
+    infoMock.mock.restore();
+  });
+
+  it("error event logger", async () => {
+    const errorMock = mock.method(console, "error", () => null);
+    
+    client.get("/timeout", { timeout: 1, loggers: { error: true } });
+
+    await assert.strictEqual(errorMock.mock.callCount(), 1, "should make console.error call");
+
+    const errorCall = errorMock.mock.calls[0];
+    assert.strictEqual(errorCall.arguments[0], "[Nexis Error]:", "should label Nexis Error");
+    assert.ok(errorCall.arguments[1], "should log Nexis Error");
+
+    errorMock.mock.restore();
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -510,23 +510,43 @@ describe("requests on test server", () => {
 
   it("request & response event loggers", async () => {
     const infoMock = mock.method(console, "info", () => null);
-    
-    await client.get("/", { loggers: { request: true, response: true }});
-    
-    assert.strictEqual(infoMock.mock.callCount(), 2, "should make two console.info calls");
+
+    await client.get("/", { loggers: { request: true, response: true } });
+
+    assert.strictEqual(
+      infoMock.mock.callCount(),
+      2,
+      "should make two console.info calls",
+    );
     const [requestCall, responseCall] = infoMock.mock.calls;
 
-    assert.strictEqual(requestCall.arguments[0], "[Nexis Request]:", "should label Nexis Request");
+    assert.strictEqual(
+      requestCall.arguments[0],
+      "[Nexis Request]:",
+      "should label Nexis Request",
+    );
     const request = requestCall.arguments[1];
     assert.strictEqual(request.method, "GET", "should log request method");
-    assert.strictEqual(request.url, "http:localhost:3000/", "should log request url");
+    assert.strictEqual(
+      request.url,
+      "http:localhost:3000/",
+      "should log request url",
+    );
     assert.ok(request.timestamp, "should log request timestamp");
 
-    assert.strictEqual(responseCall.arguments[0], "[Nexis Response]:", "should label Nexis Response");
+    assert.strictEqual(
+      responseCall.arguments[0],
+      "[Nexis Response]:",
+      "should label Nexis Response",
+    );
     const response = responseCall.arguments[1];
     assert.strictEqual(response.method, "GET", "should log response method");
     assert.strictEqual(response.status, "200 OK", "should log response status");
-    assert.strictEqual(response.url, "http:localhost:3000/", "should log response url");
+    assert.strictEqual(
+      response.url,
+      "http:localhost:3000/",
+      "should log response url",
+    );
     assert.ok(response.timestamp, "should log response timestamp");
 
     infoMock.mock.restore();
@@ -534,13 +554,23 @@ describe("requests on test server", () => {
 
   it("error event logger", async () => {
     const errorMock = mock.method(console, "error", () => null);
-    
-    client.get("/timeout", { timeout: 1, loggers: { error: true } });
 
-    await assert.strictEqual(errorMock.mock.callCount(), 1, "should make console.error call");
+    await client
+      .get("/timeout", { timeout: 1, loggers: { error: true } })
+      .catch((err) => err);
+
+    assert.strictEqual(
+      errorMock.mock.callCount(),
+      1,
+      "should make console.error call",
+    );
 
     const errorCall = errorMock.mock.calls[0];
-    assert.strictEqual(errorCall.arguments[0], "[Nexis Error]:", "should label Nexis Error");
+    assert.strictEqual(
+      errorCall.arguments[0],
+      "[Nexis Error]:",
+      "should label Nexis Error",
+    );
     assert.ok(errorCall.arguments[1], "should log Nexis Error");
 
     errorMock.mock.restore();


### PR DESCRIPTION
This pull request is to merge the branch `44-feat-implement-automatic-event-logger-handlers` into the `main` branch.

Implemented automatic event logger functions for the `request`, `response` & `error` events. These can be enabled through the `Nexis` `loggers` config param.

The `request` logger logs the `method`, `url` & `timestamp`. The `response` logger logs the `status`, `method`, `url` & `timestamp`. And the `error` logger logs the full `error` with the `req` & `res` properties including the same information as their corresponding event loggers. For example the `req` property includes the `method`, `url` & `timestamp` which is what the `request` event logger logs. But the `res` property only includes the `status` & `timestamp` because it is attached to the `req` property through the `error` object so doesn't need the `method` & `url` to connect the `request` & `response`.