### PR TITLE
63-refactor-throw-and-catch-errors-rather-than-pass-handler

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -138,16 +138,13 @@ export const decodeData: decodeData;
  * - `Bearer` scheme requires `token` param.
  * - `Digest` scheme loops through every provided param.
  */
-export type authFormatter = (
-  auth: {
-    scheme: "basic" | "bearer" | "digest";
-    token?: string;
-    username?: string;
-    password?: string;
-    [key: string]: string;
-  },
-  onReject: (err: TypeError) => void,
-) => string;
+export type authFormatter = (auth: {
+  scheme: "basic" | "bearer" | "digest";
+  token?: string;
+  username?: string;
+  password?: string;
+  [key: string]: string;
+}) => string;
 export const authFormatter: authFormatter;
 
 /**

--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -109,15 +109,8 @@ class Nexis extends EventEmitter {
     };
   }
 
-  #request(path, method, config, handlers) {
+  async #request(path, method, config, handlers) {
     config = deepMerge({ headers: { date: new Date().toUTCString() } }, config);
-
-    // Formats authorization if in json form
-    const newAuth = authFormatter(
-      config?.headers?.authorization,
-      handlers.onReject,
-    );
-    if (newAuth) config.headers.authorization = newAuth;
 
     // Add event loggers
     if (config?.loggers) {
@@ -129,6 +122,10 @@ class Nexis extends EventEmitter {
     const url = new URL(path, this.#baseURL);
     let req = defaults.req();
     try {
+      // Formats authorization if in json form
+      const newAuth = authFormatter(config?.headers?.authorization);
+      if (newAuth) config.headers.authorization = newAuth;
+
       req = protocols[url.protocol].request(
         {
           protocol: url.protocol,
@@ -139,8 +136,6 @@ class Nexis extends EventEmitter {
           ...config,
         },
         (res) => {
-          res.data = "";
-
           const chunks = [];
           res.on("data", (chunk) => {
             chunks.push(chunk);
@@ -176,36 +171,38 @@ class Nexis extends EventEmitter {
           });
         },
       );
+
+      const error = (err) => {
+        handlers.onReject(new NexisError(err, { req }));
+      };
+      req.on("error", error);
+
+      req.on("timeout", () => {
+        // Removes error event listener
+        //    To avoid timeout error being thrown again
+        //    When the request stream is destroyed by onReject handler
+        req.off("error", error);
+        req.on("error", () => null);
+
+        handlers.onReject(
+          new NexisError(
+            `Socket Connection Timeout: ${config.timeout}ms Path: ${req.path}`,
+            {
+              cause: "The server didn't respond before the timeout",
+              code: "ERR_HTTP_REQUEST_TIMEOUT",
+              req,
+            },
+          ),
+        );
+      });
+
+      this.emit("request", req);
+      // Awaits to catch protential pipeline error
+      //    In the write request handler
+      await handlers.onRequest(req);
     } catch (err) {
-      handlers.onReject(new NexisError(err));
+      handlers.onReject(new NexisError(err, { req }));
     }
-
-    const error = (err) => {
-      handlers.onReject(req, defaults.res(), err);
-    };
-    req.on("error", error);
-
-    req.on("timeout", () => {
-      // Removes error event listener
-      //    To avoid timeout error being thrown again
-      //    When the request stream is destroyed by onReject handler
-      req.off("error", error);
-      req.on("error", () => null);
-
-      handlers.onReject(
-        new NexisError(
-          `Socket Connection Timeout: ${config.timeout}ms Path: ${req.path}`,
-          {
-            cause: "The server didn't respond before the timeout",
-            code: "ERR_HTTP_REQUEST_TIMEOUT",
-            req,
-          },
-        ),
-      );
-    });
-
-    this.emit("request", req);
-    handlers.onRequest(req);
   }
 
   read(path = defaults.path, method = defaults.method["read"], configOrCb, cb) {
@@ -238,13 +235,11 @@ class Nexis extends EventEmitter {
       config = deepMerge({ headers }, config);
 
       const handlers = this.#generateHandlers(resolve, reject, callback);
-      handlers.onRequest = function handleRequest(req) {
+      handlers.onRequest = async function handleRequest(req) {
         if (!data) return req.end();
 
         // Feeds data to req writable stream
-        pipeline(Readable.from(data), req).catch((err) => {
-          this.onReject(req, defaults.res(), err);
-        });
+        return await pipeline(Readable.from(data), req);
       };
 
       this.#request(path, method, config, handlers);

--- a/lib/utils/authFormatter.js
+++ b/lib/utils/authFormatter.js
@@ -2,7 +2,7 @@ const NexisError = require("../core/NexisError");
 
 exports = module.exports = authFormatter;
 
-function authFormatter(auth, onReject) {
+function authFormatter(auth) {
   // Only formats if is an object
   if (!auth || typeof auth !== "object") return auth;
 
@@ -28,10 +28,8 @@ function authFormatter(auth, onReject) {
       return string.slice(0, string.length - 1);
 
     default:
-      onReject(
-        new NexisError("Invalid Auth Scheme", {
-          code: "ERR_INVALID_AUTH_SCHEME",
-        }),
-      );
+      throw new NexisError("Invalid Auth Scheme", {
+        code: "ERR_INVALID_AUTH_SCHEME",
+      });
   }
 }

--- a/tests/authFormatter.test.js
+++ b/tests/authFormatter.test.js
@@ -34,26 +34,13 @@ describe("Auth Formatter", () => {
     assert.strictEqual(authFormatter(auth), auth);
   });
 
-  it("should reject invalid auth scheme", { timeout: 500 }, (t, done) => {
+  it("should reject invalid auth scheme", { timeout: 500 }, () => {
     const auth = { scheme: "invalid" };
-    new Promise((resolve, reject) => authFormatter(auth, reject)).catch(
-      (error) => {
-        try {
-          assert.strictEqual(
-            error instanceof NexisError,
-            true,
-            "should reject NexisError",
-          );
-          assert.strictEqual(
-            error.message.includes("Invalid Auth Scheme"),
-            true,
-            "error should include 'Invalid Auth Scheme'",
-          );
-          done();
-        } catch (err) {
-          done(err);
-        }
-      },
+    assert.throws(
+      () => authFormatter(auth),
+      (err) =>
+        err instanceof NexisError &&
+        err.message.includes("Invalid Auth Scheme"),
     );
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -575,4 +575,18 @@ describe("requests on test server", () => {
 
     errorMock.mock.restore();
   });
+
+  it("should handle pipeline error", () => {
+    // Error in pipeline method caused by incorrect format of body
+    //    Because the incorrect content-type is provided
+    assert.rejects(
+      async () =>
+        await client.post(
+          "/",
+          { message: "Hello" },
+          { headers: { "content-type": "plain/text" } },
+        ),
+      (err) => err instanceof nexis.NexisError,
+    );
+  });
 });


### PR DESCRIPTION
This pull request is to merge the branch `63-refactor-throw-and-catch-errors-rather-than-pass-handler` into the `main` branch.

Reduced the passing of the `onReject` handler by instead throwing errors than using `try/catch` blocks to then call the `onReject` handler. Additionally, fixed some error handling these include the `req` `error`  listener and the catching of an `error` thrown internally by the `pipeline` method.