### PR TITLE
66-refactor-handle-promise-and-handler-generating-in-request-method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,7 +54,7 @@ export type NexisCallback = (
  */
 export type NexisMethodRequest = (
   path?: string | URL,
-  configOrCb?: http.RequestOptions | NexisCallback,
+  config?: http.RequestOptions | NexisCallback,
   cb?: NexisCallback,
 ) => Promise<http.IncomingMessage>;
 
@@ -228,7 +228,7 @@ export class Nexis extends EventEmitter<NexisEvents> {
   read(
     path?: string | URL,
     method?: "get" | "delete",
-    configOrCb?: http.RequestOptions | NexisCallback,
+    config?: http.RequestOptions | NexisCallback,
     cb?: NexisCallback,
   ): Promise<http.IncomingMessage>;
 
@@ -238,7 +238,7 @@ export class Nexis extends EventEmitter<NexisEvents> {
   write(
     path?: string | URL,
     method?: "post" | "put" | "patch",
-    configOrCb?: http.RequestOptions | NexisCallback,
+    config?: http.RequestOptions | NexisCallback,
     cb?: NexisCallback,
   ): Promise<http.IncomingMessage>;
 

--- a/lib/core/Nexis.js
+++ b/lib/core/Nexis.js
@@ -106,217 +106,206 @@ class Nexis extends EventEmitter {
       });
   }
 
-  #handleCallbackConfig(configOrCb, cb) {
-    // Resolve callback
-    if (typeof configOrCb === "function") {
-      cb = configOrCb;
-      configOrCb = {};
-    }
-
-    return [configOrCb, cb];
-  }
-
   #mergeConfigs(config) {
-    // Merge configs
+    // Merges default & attribute configs with input config
     return deepMerge(deepMerge(defaults.config(), this.#config), config);
   }
 
-  #generateHandlers(resolve, reject, cb) {
-    const handleResolve = (res) => {
-      this.emit("response", res);
-      cb && cb(res);
-      resolve(res);
-    };
-
-    const handleReject = (err) => {
-      if (err?.req instanceof http.ClientRequest) err.req.destroy(err);
-      if (err?.res instanceof http.IncomingMessage) err.res.destroy(err);
-
-      // Handles error by first calling event listeners if there are
-      //    Then finishing handling through callback or rejection
-      if (this.listenerCount("error") > 0) this.emit("error", err);
-      if (cb && typeof cb === "function") {
-        cb(err?.res, err);
-      } else {
-        reject(err);
-      }
-    };
-
-    return {
-      onResolve: handleResolve,
-      onReject: handleReject,
-    };
-  }
-
   async #request(path, method, config, handlers) {
-    config = deepMerge({ headers: { date: new Date().toUTCString() } }, config);
-
-    // Add event loggers
-    if (config?.loggers) {
-      Object.entries(config.loggers).forEach(([event, bool]) => {
-        if (bool && loggers[event]) this.once(event, loggers[event]);
-      });
-    }
-
-    const url = new URL(path, this.#baseURL);
-    let req = defaults.req();
-    try {
-      // Formats authorization if in json form
-      const newAuth = authFormatter(config?.headers?.authorization);
-      if (newAuth) config.headers.authorization = newAuth;
-
-      req = protocols[url.protocol].request(
-        {
-          protocol: url.protocol,
-          hostname: url.hostname,
-          port: url.port,
-          path: url.pathname + url.search,
-          method,
-          ...config,
-        },
-        (res) => {
-          const chunks = [];
-          res.on("data", (chunk) => {
-            chunks.push(chunk);
-          });
-
-          res.on("end", () => {
-            // Combines chunks
-            res.data = Buffer.concat(chunks).toString();
-
-            this.emit("data", res.data);
-
-            // Converts response data based off headers
-            //      Parse json object or construct URLSearchParams
-            res.data = decodeData(res.data, res.getHeader("content-type"));
-
-            // Handle redirect
-            if (
-              config?.maxRedirects > 0 &&
-              res.statusCode === 301 &&
-              res.getHeader("location")
-            ) {
-              this.emit("redirect", res, config);
-              const { maxRedirects, ...other } = config;
-              return this.#request(
-                res.getHeader("location"),
-                method,
-                { ...other, maxRedirects: maxRedirects - 1 },
-                handlers,
-              );
-            }
-
-            handlers.onResolve(res);
-          });
-        },
-      );
-
-      const error = (err) => {
-        handlers.onReject(new NexisError(err, { req }));
-      };
-      req.on("error", error);
-
-      req.on("timeout", () => {
-        // Removes error event listener
-        //    To avoid timeout error being thrown again
-        //    When the request stream is destroyed by onReject handler
-        req.off("error", error);
-        req.on("error", () => null);
-
-        handlers.onReject(
-          new NexisError(
-            `Socket Connection Timeout: ${config.timeout}ms Path: ${req.path}`,
-            {
-              cause: "The server didn't respond before the timeout",
-              code: "ERR_HTTP_REQUEST_TIMEOUT",
-              req,
-            },
-          ),
-        );
-      });
-
-      this.emit("request", req);
-      // Awaits to catch protential pipeline error
-      //    In the write request handler
-      await handlers.onRequest(req);
-    } catch (err) {
-      handlers.onReject(new NexisError(err, { req }));
-    }
-  }
-
-  read(path = defaults.path, method = defaults.method["read"], configOrCb, cb) {
     return new Promise((resolve, reject) => {
+      let { cb, onRequest } = handlers;
       // Resolve callback & config
-      let [config, callback] = this.#handleCallbackConfig(configOrCb, cb);
-
-      const handlers = this.#generateHandlers(resolve, reject, callback);
-      handlers.onRequest = function handleRequest(req) {
-        req.end();
-      };
-
-      try {
-        this.#validatePathMethodCallback(path, method, callback);
-        config = this.#mergeConfigs(config);
-      } catch (err) {
-        return handlers.onReject(err);
+      if (typeof config === "function") {
+        cb = config;
+        config = {};
       }
 
-      this.#request(path, method, config, handlers);
+      const handleResolve = (res) => {
+        this.emit("response", res);
+        typeof cb === "function" && cb(res);
+        resolve(res);
+      };
+
+      const handleReject = (err) => {
+        if (err?.req instanceof http.ClientRequest) err.req.destroy(err);
+        if (err?.res instanceof http.IncomingMessage) err.res.destroy(err);
+
+        // Handles error by first calling event listeners if there are
+        //    Then finishing handling through callback or rejection
+        if (this.listenerCount("error") > 0) this.emit("error", err);
+        if (typeof cb === "function") {
+          cb(err?.res, err);
+        } else {
+          reject(err);
+        }
+      };
+
+      // Pre-define request object to be used in the catch block
+      let req = defaults.req();
+      // Is wrapped in async function to be able to await for potential error from dispatch method
+      //    This allows the catch block to catch the error
+      //    Better code practise then to make the Promise callback function async
+      const safeWrapper = async () => {
+        try {
+          this.#validatePathMethodCallback(path, method, cb);
+          config = this.#mergeConfigs(config); // Merges default & attribute configs with input config
+
+          // Auto constructs date header
+          config = deepMerge(
+            { headers: { date: new Date().toUTCString() } },
+            config,
+          );
+
+          // Add event loggers
+          if (config?.loggers) {
+            Object.entries(config.loggers).forEach(([event, bool]) => {
+              if (bool && loggers[event]) this.once(event, loggers[event]);
+            });
+          }
+
+          // Formats authorization if in json form
+          const newAuth = authFormatter(config?.headers?.authorization);
+          if (newAuth) config.headers.authorization = newAuth;
+
+          let url = new URL(path, this.#baseURL);
+          const dispatch = async (path, maxRedirects) => {
+            url = new URL(path, url); // Updates request url with redirected path
+            req = protocols[url.protocol].request(
+              {
+                protocol: url.protocol,
+                hostname: url.hostname,
+                port: url.port,
+                path: url.pathname + url.search,
+                method,
+                ...config,
+              },
+              (res) => {
+                const chunks = [];
+                res.on("data", (chunk) => {
+                  chunks.push(chunk);
+                });
+
+                res.on("end", () => {
+                  // Combines chunks
+                  res.data = Buffer.concat(chunks).toString();
+
+                  this.emit("data", res.data);
+
+                  // Converts response data based off headers
+                  //      Parse json object or construct URLSearchParams
+                  res.data = decodeData(
+                    res.data,
+                    res.getHeader("content-type"),
+                  );
+
+                  // Handle redirect
+                  if (
+                    maxRedirects > 0 &&
+                    res.statusCode === 301 &&
+                    res.getHeader("location")
+                  ) {
+                    this.emit("redirect", res, config);
+                    return dispatch(
+                      res.getHeader("location"),
+                      maxRedirects - 1,
+                    );
+                  }
+
+                  handleResolve(res);
+                });
+              },
+            );
+
+            const error = (err) => {
+              handleReject(new NexisError(err, { req }));
+            };
+            req.on("error", error);
+
+            req.on("timeout", () => {
+              // Removes error event listener
+              //    To avoid timeout error being thrown again
+              //    When the request stream is destroyed by onReject handler
+              req.off("error", error);
+              req.on("error", () => null);
+
+              handleReject(
+                new NexisError(
+                  `Socket Connection Timeout: ${config.timeout}ms Path: ${req.path}`,
+                  {
+                    cause: "The server didn't respond before the timeout",
+                    code: "ERR_HTTP_REQUEST_TIMEOUT",
+                    req,
+                  },
+                ),
+              );
+            });
+
+            this.emit("request", req);
+            // Awaits to catch protential pipeline error
+            //    In the write request handler
+            await onRequest(req, config);
+          };
+
+          await dispatch(path, config?.maxRedirects ?? 0);
+        } catch (err) {
+          handleReject(new NexisError(err, { req }));
+        }
+      };
+
+      safeWrapper();
     });
+  }
+
+  read(path = defaults.path, method = defaults.method["read"], config, cb) {
+    const handlers = {
+      cb,
+      onRequest: function handleRequest(req) {
+        req.end();
+      },
+    };
+
+    return this.#request(path, method, config, handlers);
   }
 
   write(
     path = defaults.path,
     method = defaults.method["write"],
     body,
-    configOrCb,
+    config,
     cb,
   ) {
-    return new Promise((resolve, reject) => {
-      // Resolve callback & merge configs
-      let [config, callback] = this.#handleCallbackConfig(configOrCb, cb);
+    const handlers = {
+      cb,
+      onRequest: function handleRequest(req, config) {
+        // Merges in auto config based off body data
+        //    For example, the content-type & length
+        const [data, headers] = encodeConfigBody(body);
+        deepMerge({ headers }, config);
 
-      // Pre-defines data & headers
-      //    Cause handleRequest method uses data
-      let data, headers;
-
-      const handlers = this.#generateHandlers(resolve, reject, callback);
-      handlers.onRequest = async function handleRequest(req) {
         if (!data) return req.end();
 
         // Feeds data to req writable stream
-        return await pipeline(Readable.from(data), req);
-      };
+        return pipeline(Readable.from(data), req);
+      },
+    };
 
-      try {
-        this.#validatePathMethodCallback(path, method, callback);
-        config = this.#mergeConfigs(config);
-
-        // Encodes data & merges auto configuration
-        [data, headers] = encodeConfigBody(body);
-        config = deepMerge({ headers }, config);
-      } catch (err) {
-        return handlers.onReject(err);
-      }
-
-      this.#request(path, method, config, handlers);
-    });
+    return this.#request(path, method, config, handlers);
   }
 }
 
 // Creates read requests
 ["get", "delete"].forEach(
   (method) =>
-    (Nexis.prototype[method] = async function (path, configOrCb, cb) {
-      return await this.read(path, method, configOrCb, cb);
+    (Nexis.prototype[method] = function (path, config, cb) {
+      return this.read(path, method, config, cb);
     }),
 );
 
 // Creates write requests
 ["post", "put", "patch"].forEach(
   (method) =>
-    (Nexis.prototype[method] = async function (path, body, configOrCb, cb) {
-      return await this.write(path, method, body, configOrCb, cb);
+    (Nexis.prototype[method] = function (path, body, config, cb) {
+      return this.write(path, method, body, config, cb);
     }),
 );
 


### PR DESCRIPTION
This pull request is to merge the branch `66-refactor-handle-promise-and-handler-generating-in-request-method` into the `main` branch.

Removed the repetitive code of the `read` & `write` methods that involved making the `Promise` and generating the `handlers`. This was done by creating the promise in the `#request` method and updating the method to also merge the `configs` & validate inputs. For the `write` method to merge in the auto header config it is now done in the `handleRequest` method which updates the config by reference.

Additionally, cause the `handleResolve` & `handleReject` methods could be directly created in the `#request` method, the `Promise` `resolve` & `reject` methods didn't need to be passed. Also, a `dispatch` function is created that just performs the dispatching request process, which is called when redirecting and also reduces passing as it remains in the same scope. Also the `try/catch` blocks have been wrapped in a `async` function because errors thrown in other `async` functions need to be awaited to be able to be caught & its bad practise to make the `Promise` callback function `async`.